### PR TITLE
macro expansion support

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -26,7 +26,7 @@ import (
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/google/uuid"
-	sqlite3 "github.com/mattn/go-sqlite3"
+	"github.com/mattn/go-sqlite3"
 )
 
 // Rosmar implementation of a collection-aware bucket.
@@ -41,6 +41,7 @@ type Bucket struct {
 	nextExp     uint32         // Timestamp when expTimer will run (0 if never)
 	serial      uint32         // Serial number for logging
 	inMemory    bool           // True if it's an in-memory database
+	uuid        string         // unique identifier for bucket
 }
 
 type collectionsMap = map[sgbucket.DataStoreNameImpl]*Collection
@@ -281,6 +282,7 @@ func parseDBFileURL(urlStr string) (*url.URL, error) {
 
 func (bucket *Bucket) initializeSchema(bucketName string) (err error) {
 	uuid := uuid.New().String()
+	bucket.uuid = uuid
 	_, err = bucket.db().Exec(kSchema,
 		sql.Named("NAME", bucketName),
 		sql.Named("UUID", uuid),

--- a/collection+xattrs.go
+++ b/collection+xattrs.go
@@ -20,15 +20,6 @@ import (
 
 type semiParsedXattrs = map[string]json.RawMessage
 
-// PersistedHybridLogicalVector is the persisted representation of the Hybrid Logical Vector, needed to update _sync xattrs
-type PersistedHybridLogicalVector struct {
-	CurrentVersionCAS string            `json:"cvCas,omitempty"`
-	SourceID          string            `json:"src,omitempty"`
-	Version           string            `json:"vrs,omitempty"`
-	MergeVersions     map[string]string `json:"mv,omitempty"`
-	PreviousVersions  map[string]string `json:"pv,omitempty"`
-}
-
 //////// SGBUCKET XATTR STORE INTERFACE
 
 // Get a single xattr value.
@@ -643,6 +634,10 @@ func (e *event) macroExpand(value string, casServerFormat string, bucketUUID str
 // Sets JSON properties "cas" to the given `cas`, and "value_crc" to CRC checksum of `docValue`.
 func (e *event) expandSyncXattrMacros(xattr any, bucketUUID string, mutateSpec *sgbucket.MutateInOptions) error {
 	var err error
+	if mutateSpec == nil {
+		return fmt.Errorf("nil mutate spec provided to macro expansion")
+	}
+
 	if xattrMap, ok := xattr.(map[string]any); ok {
 		// create server format of cas value
 		casBytes := make([]byte, 8)


### PR DESCRIPTION
Summary of changes:

1. Uptake of sg-bucket changes 
2. adding bucket UUID to bucket struct (issue with using query more than once) 
3. Pass sg-bucket mutate in options down the stack to the macro expansion code Jens already implemented
4. Add some (sort of) macro expansion code to the path by iterating through the spec provided, expand and insert into the xattr

