### PR TITLE
CBG-3381 lock bucket.db() function

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -299,6 +299,9 @@ func (bucket *Bucket) initializeSchema(bucketName string) (err error) {
 // If the bucket has been closed, it returns a special `closedDB` value that will return
 // ErrBucketClosed from any call.
 func (bucket *Bucket) db() queryable {
+	bucket.mutex.Lock()
+	defer bucket.mutex.Unlock()
+
 	if db := bucket._db; db != nil {
 		return db
 	} else {


### PR DESCRIPTION
If `Bucket.Close()` and `Collection.Update()` are called simultaneously, it would result in a data race below. Fixed this by locking `bucket._db` (now bucket.sqliteDB) and having a locked and unlocked accessor functions.

I preferred to keep the the accessor methods even for the non mutexed version so I don't have to always check if `Bucket.sqliteDB == nil` and return `ErrBucketClosed` 

```
WARNING: DATA RACE
--
12:41:39 Write at 0x00c00413f570 by goroutine 30562:
12:41:39   github.com/couchbaselabs/rosmar.(*Bucket).Close()
12:41:39       /home/ubuntu/workspace/sgw-unix-build/3.2.0/enterprise/godeps/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20230825143155-1a2061661a4b/bucket_api.go:67 +0x1f8
12:41:39   github.com/couchbase/sync_gateway/base.(*LeakyBucket).Close()
12:41:39       /home/ubuntu/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/base/leaky_bucket.go:52 +0x70
12:41:39   github.com/couchbase/sync_gateway/base.(*TestBucketPool).GetWalrusTestBucket.func1()
12:41:39       /home/ubuntu/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/base/main_test_bucket_pool.go:262 +0x230
12:41:39   github.com/couchbase/sync_gateway/base.TestBucket.Close()
12:41:39       /home/ubuntu/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/base/util_testing.go:73 +0xec
12:41:39   github.com/couchbase/sync_gateway/rest.SetupSGRPeers.func1()
12:41:39       /home/ubuntu/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/rest/utilities_testing_resttester.go:334 +0xb8
12:41:39   runtime.deferreturn()
12:41:39       /home/ubuntu/cbdeps/go1.20.3/src/runtime/panic.go:476 +0x30
12:41:39   testing.tRunner()
12:41:39       /home/ubuntu/cbdeps/go1.20.3/src/testing/testing.go:1576 +0x180
12:41:39   testing.(*T).Run.func1()
12:41:39       /home/ubuntu/cbdeps/go1.20.3/src/testing/testing.go:1629 +0x40
12:41:39
12:41:39 Previous read at 0x00c00413f570 by goroutine 31021:
12:41:39   github.com/couchbaselabs/rosmar.(*Bucket).db()
12:41:39       /home/ubuntu/workspace/sgw-unix-build/3.2.0/enterprise/godeps/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20230825143155-1a2061661a4b/bucket.go:302 +0x1b0
12:41:39   github.com/couchbaselabs/rosmar.(*Collection).db()
12:41:39       /home/ubuntu/workspace/sgw-unix-build/3.2.0/enterprise/godeps/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20230825143155-1a2061661a4b/collection.go:61 +0x188
12:41:39   github.com/couchbaselabs/rosmar.(*Collection).Update()
12:41:39       /home/ubuntu/workspace/sgw-unix-build/3.2.0/enterprise/godeps/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20230825143155-1a2061661a4b/collection.go:429 +0x1c0
12:41:39   github.com/couchbase/sync_gateway/base.(*LeakyDataStore).Update()
12:41:39       /home/ubuntu/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/base/leaky_datastore.go:149 +0x1c4
12:41:39   github.com/couchbase/sync_gateway/base.(*LeakyDataStore).Update()
12:41:39       /home/ubuntu/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/base/leaky_datastore.go:149 +0x1c4
12:41:39   github.com/couchbase/sync_gateway/auth.(*Authenticator).getPrincipal()
12:41:39       /home/ubuntu/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/auth/auth.go:169 +0x1ac
12:41:39   github.com/couchbase/sync_gateway/auth.(*Authenticator).GetUser()
12:41:39       /home/ubuntu/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/auth/auth.go:124 +0x108
12:41:39   github.com/couchbase/sync_gateway/db.(*DatabaseCollectionWithUser).ReloadUser()
12:41:39       /home/ubuntu/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/db/database_collection.go:229 +0xa8
12:41:39   github.com/couchbase/sync_gateway/db.(*DatabaseCollectionWithUser).SimpleMultiChangesFeed.func1()
12:41:39       /home/ubuntu/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/db/changes.go:652 +0x2b8
12:41:39
12:41:39 Goroutine 30562 (running) created at:
12:41:39   testing.(*T).Run()
12:41:39       /home/ubuntu/cbdeps/go1.20.3/src/testing/testing.go:1629 +0x5b4
12:41:39   github.com/couchbase/sync_gateway/rest/replicatortest.TestReplicatorReconnectBehaviour()
12:41:39       /home/ubuntu/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/rest/replicatortest/replicator_test.go:2367 +0x114
12:41:39   testing.tRunner()
12:41:39       /home/ubuntu/cbdeps/go1.20.3/src/testing/testing.go:1576 +0x180
12:41:39   testing.(*T).Run.func1()
12:41:39       /home/ubuntu/cbdeps/go1.20.3/src/testing/testing.go:1629 +0x40
12:41:39
12:41:39 Goroutine 31021 (running) created at:
12:41:39   github.com/couchbase/sync_gateway/db.(*DatabaseCollectionWithUser).SimpleMultiChangesFeed()
12:41:39       /home/ubuntu/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/db/changes.go:618 +0x3dc
12:41:39   github.com/couchbase/sync_gateway/db.(*DatabaseCollectionWithUser).MultiChangesFeed()
12:41:39       /home/ubuntu/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/db/changes.go:545 +0xf4
12:41:39   github.com/couchbase/sync_gateway/db.GenerateChanges()
12:41:39       /home/ubuntu/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/db/changes.go:1415 +0x364
12:41:39   github.com/couchbase/sync_gateway/db.generateBlipSyncChanges()
12:41:39       /home/ubuntu/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/db/changes.go:1342 +0x98
12:41:39   github.com/couchbase/sync_gateway/db.(*blipHandler).sendChanges()
12:41:39       /home/ubuntu/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/db/blip_handler.go:438 +0x4e0
12:41:39   github.com/couchbase/sync_gateway/db.(*blipHandler).handleSubChanges.func2()
12:41:39       /home/ubuntu/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/db/blip_handler.go:330 +0x598
12:41:39 ==================
12:41:39 2023-09-06T16:39:39.046Z [WRN] c:[3ff08621] col:sg_test_0 Error reloading user during changes initialization "<ud>alice</ud>": sql: database is closed -- db.(*DatabaseCollectionWithUser).SimpleMultiChangesFeed.func1() at changes.go:653
12:41:39 2023-09-06T16:39:39.048Z [INF] t:TestReplicatorReconnectBehaviour/maxbackoff_1 b:sg_int_rosmar_ca23f58e28464c922fcd6362ff5a051e Design docs for current view version (2.1) do not exist - creating...
```
