### PR TITLE
CBG-3540 keep url read-only once bucket is open

### DIFF
--- a/bucket_api.go
+++ b/bucket_api.go
@@ -78,7 +78,6 @@ func (bucket *Bucket) CloseAndDelete() (err error) {
 	defer bucket.mutex.Unlock()
 	if bucket.url != "" {
 		err = DeleteBucketAt(bucket.url)
-		bucket.url = ""
 	}
 	return err
 }


### PR DESCRIPTION
By making url immutable we don't have to lock when it is being read (e.g. in `Collection.postNewEvent`).

