### PR TITLE
CBG-3271 allow in memory buckets to persist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,11 +61,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.3
+          cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.0
-          args: --timeout 3m # this is slow only in github actions
+          version: v1.55.0
 
   test-race:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,9 @@
 
 # config file for golangci-lint
 
+run:
+  timeout: 3m
+
 linters:
   enable:
     #- bodyclose # checks whether HTTP response body is closed successfully

--- a/README.md
+++ b/README.md
@@ -21,10 +21,6 @@ Rosmar supports:
 
 ## 1. Building and Using It
 
-Rosmar requires an updated version of sg-bucket -- this is on the `feature/walrus-xattrs` branch. Rosmar's `go.mod` file points to the appropriate commit.
-
-To use Rosmar in Sync Gateway, check out the latter's `feature/walrus_xattrs` branch, in which Walrus has been replaced with Rosmar.
-
 To run SG normally with a Rosmar bucket, use a non-persistent SG config file like this one:
 
 ```json
@@ -125,6 +121,10 @@ A Bucket is identified by a URL with the scheme `rosmar:` and a path. The path i
 The special URL `rosmar:/?mode=memory` opens an ephemeral in-memory database. Don't hardcode that URL; use the constant `InMemoryURL` instead.
 
 > Note: The directory contains the SQLite database file `rosmar.sqlite` plus SQLite side files. But its contents should be considered opaque.
+
+### Bucket Persistence
+
+For in memory buckets, closing a bucket does not delete the bucket from memory, representing how Couchbase Server would not delete the bucket. In order to delete the bucket from memory, call `Bucket.CloseAndDelete`.
 
 ### Metadata Purging
 

--- a/bucket-registry.go
+++ b/bucket-registry.go
@@ -62,7 +62,7 @@ func (r *bucketRegistry) getCachedBucket(name string) *Bucket {
 // unregisterBucket removes a Bucket from the registry. Must be called before closing.
 func (r *bucketRegistry) unregisterBucket(bucket *Bucket) {
 	name := bucket.name
-	debug("UNregisterBucket %v at %s", bucket, name, bucket.url)
+	debug("UNregisterBucket %v %s at %s", bucket, name, bucket.url)
 	r.lock.Lock()
 	defer r.lock.Unlock()
 

--- a/bucket.go
+++ b/bucket.go
@@ -9,6 +9,7 @@
 package rosmar
 
 import (
+	"context"
 	"database/sql"
 	_ "embed"
 	"errors"
@@ -16,7 +17,6 @@ import (
 	"io/fs"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -32,15 +32,17 @@ import (
 // Rosmar implementation of a collection-aware bucket.
 // Implements sgbucket interfaces BucketStore, DynamicDataStoreBucket, DeletableStore, MutationFeedStore2.
 type Bucket struct {
-	url         string         // Filesystem path or other URL
-	name        string         // Bucket name
-	collections collectionsMap // Collections, indexed by DataStoreName
-	mutex       sync.Mutex     // mutex for synchronized access to Bucket
-	sqliteDB    *sql.DB        // SQLite database handle (do not access; call db() instead)
-	expTimer    *time.Timer    // Schedules expiration of docs
-	nextExp     uint32         // Timestamp when expTimer will run (0 if never)
-	serial      uint32         // Serial number for logging
-	inMemory    bool           // True if it's an in-memory database
+	url             string         // Filesystem path or other URL
+	name            string         // Bucket name
+	collections     collectionsMap // Collections, indexed by DataStoreName
+	collectionFeeds map[sgbucket.DataStoreNameImpl][]*dcpFeed
+	mutex           *sync.Mutex // mutex for synchronized access to Bucket
+	sqliteDB        *sql.DB     // SQLite database handle (do not access; call db() instead)
+	expTimer        *time.Timer // Schedules expiration of docs
+	nextExp         *uint32     // Timestamp when expTimer will run (0 if never)
+	serial          uint32      // Serial number for logging
+	inMemory        bool        // True if it's an in-memory database
+	closed          bool        // represents state when it is closed
 }
 
 type collectionsMap = map[sgbucket.DataStoreNameImpl]*Collection
@@ -76,33 +78,42 @@ const (
 	ReOpenExisting        // Open an existing bucket, or fail if none exists.
 )
 
-// OpenBucketFromPath opens a bucket from a filesystem path. See OpenBucket for details.
-func OpenBucketFromPath(path string, mode OpenMode) (*Bucket, error) {
-	return OpenBucket(uriFromPath(path), mode)
-}
-
 // Creates a new bucket, or opens an existing one.
 //
 // The URL should have the scheme 'rosmar' or 'file' and a filesystem path.
 // The path represents a directory; the SQLite database files will be created inside it.
 // Alternatively, the `InMemoryURL` can be given, to create an in-memory bucket with no file.
-func OpenBucket(urlStr string, mode OpenMode) (bucket *Bucket, err error) {
+func OpenBucket(urlStr string, bucketName string, mode OpenMode) (b *Bucket, err error) {
 	traceEnter("OpenBucket", "%q, %d", urlStr, mode)
 	defer func() { traceExit("OpenBucket", err, "ok") }()
+
 	u, err := encodeDBURL(urlStr)
 	if err != nil {
 		return nil, err
 	}
 	urlStr = u.String()
 
+	bucket := getInMemoryBucket(bucketName)
+	if bucket != nil {
+		if mode == CreateNew {
+			return nil, fs.ErrExist
+		}
+		if urlStr != bucket.url {
+			return nil, fmt.Errorf("bucket %q already exists at %q, will not open at %q", bucketName, bucket.url, urlStr)
+		}
+		b = bucket.copy()
+		registerBucket(b)
+		return b, nil
+
+	}
+
 	query := u.Query()
 	inMemory := query.Get("mode") == "memory"
-	var bucketName string
 	if inMemory {
 		if mode == ReOpenExisting {
 			return nil, fs.ErrNotExist
 		}
-		bucketName = "memory"
+		u = u.JoinPath(bucketName)
 	} else {
 		dir := u.Path
 		if runtime.GOOS == "windows" {
@@ -124,7 +135,6 @@ func OpenBucket(urlStr string, mode OpenMode) (bucket *Bucket, err error) {
 
 		query.Set("mode", ifelse(mode == ReOpenExisting, "rw", "rwc"))
 		u = u.JoinPath(kDBFilename)
-		bucketName = path.Base(dir)
 	}
 
 	// See https://github.com/mattn/go-sqlite3#connection-string
@@ -160,12 +170,20 @@ func OpenBucket(urlStr string, mode OpenMode) (bucket *Bucket, err error) {
 	db.SetMaxOpenConns(ifelse(inMemory, 1, kMaxOpenConnections))
 
 	bucket = &Bucket{
-		url:         urlStr,
-		sqliteDB:    db,
-		collections: make(map[sgbucket.DataStoreNameImpl]*Collection),
-		inMemory:    inMemory,
-		serial:      serial,
+		url:             urlStr,
+		sqliteDB:        db,
+		collections:     make(map[sgbucket.DataStoreNameImpl]*Collection),
+		collectionFeeds: make(map[sgbucket.DataStoreNameImpl][]*dcpFeed),
+		mutex:           &sync.Mutex{},
+		nextExp:         new(uint32),
+		inMemory:        inMemory,
+		serial:          serial,
 	}
+	defer func() {
+		if err != nil {
+			_ = bucket.CloseAndDelete(context.TODO())
+		}
+	}()
 
 	// Initialize the schema if necessary:
 	var vers int
@@ -180,6 +198,10 @@ func OpenBucket(urlStr string, mode OpenMode) (bucket *Bucket, err error) {
 	} else {
 		bucket.scheduleExpiration()
 	}
+	err = bucket.setName(bucketName)
+	if err != nil {
+		return nil, err
+	}
 
 	registerBucket(bucket)
 	return bucket, err
@@ -190,18 +212,14 @@ func OpenBucket(urlStr string, mode OpenMode) (bucket *Bucket, err error) {
 // bucket name. The bucket will be opened in a subdirectory of the directory URL.
 func OpenBucketIn(dirUrlStr string, bucketName string, mode OpenMode) (*Bucket, error) {
 	if isInMemoryURL(dirUrlStr) {
-		bucket, err := OpenBucket(dirUrlStr, mode)
-		if err == nil {
-			err = bucket.SetName(bucketName)
-		}
-		return bucket, err
+		return OpenBucket(dirUrlStr, bucketName, mode)
 	}
 
 	u, err := parseDBFileURL(dirUrlStr)
 	if err != nil {
 		return nil, err
 	}
-	return OpenBucket(u.JoinPath(bucketName).String(), mode)
+	return OpenBucket(u.JoinPath(bucketName).String(), bucketName, mode)
 }
 
 // Deletes the bucket at the given URL, i.e. the filesystem directory at its path, if it exists.
@@ -219,10 +237,6 @@ func DeleteBucketAt(urlStr string) (err error) {
 		return err
 	} else if u.Query().Get("mode") == "memory" {
 		return nil
-	}
-
-	if len(bucketsAtURL(u.String())) > 0 {
-		return fmt.Errorf("there is a Bucket open at that URL")
 	}
 
 	// For safety's sake, don't delete just any directory. Ensure it contains a db file:
@@ -288,8 +302,7 @@ func (bucket *Bucket) initializeSchema(bucketName string) (err error) {
 		sql.Named("COLL", sgbucket.DefaultCollection),
 	)
 	if err != nil {
-		_ = bucket.CloseAndDelete()
-		panic("Rosmar SQL schema is invalid: " + err.Error())
+		return fmt.Errorf("Rosmar SQL schema is invalid: %w", err)
 	}
 	bucket.name = bucketName
 	return
@@ -306,11 +319,10 @@ func (bucket *Bucket) db() queryable {
 
 // Returns the database handle as a `queryable` interface value. This is the same as `db()` without locking. This is not safe to call without bucket.mutex being locked the caller.
 func (bucket *Bucket) _db() queryable {
-	if db := bucket.sqliteDB; db != nil {
-		return db
-	} else {
+	if bucket.closed {
 		return closedDB{}
 	}
+	return bucket.sqliteDB
 }
 
 // Runs a function within a SQLite transaction.
@@ -322,7 +334,7 @@ func (bucket *Bucket) inTransaction(fn func(txn *sql.Tx) error) error {
 	bucket.mutex.Lock()
 	defer bucket.mutex.Unlock()
 
-	if bucket.sqliteDB == nil {
+	if bucket.closed {
 		return ErrBucketClosed
 	}
 
@@ -358,6 +370,23 @@ func (bucket *Bucket) inTransaction(fn func(txn *sql.Tx) error) error {
 		break
 	}
 	return remapError(err)
+}
+
+// Make a copy of the bucket, but it holds the same underlying structures.
+func (b *Bucket) copy() *Bucket {
+	r := &Bucket{
+		url:             b.url,
+		name:            b.name,
+		collectionFeeds: b.collectionFeeds,
+		collections:     make(collectionsMap),
+		mutex:           b.mutex,
+		sqliteDB:        b.sqliteDB,
+		expTimer:        b.expTimer,
+		nextExp:         b.nextExp,
+		serial:          b.serial,
+		inMemory:        b.inMemory,
+	}
+	return r
 }
 
 // uriFromPath converts a file path to a rosmar URI. On windows, these need to have forward slashes and drive letters will have an extra /, such as romsar://c:/foo/bar.

--- a/bucket.go
+++ b/bucket.go
@@ -93,7 +93,7 @@ func OpenBucket(urlStr string, bucketName string, mode OpenMode) (b *Bucket, err
 	}
 	urlStr = u.String()
 
-	bucket := getInMemoryBucket(bucketName)
+	bucket := getCachedBucket(bucketName)
 	if bucket != nil {
 		if mode == CreateNew {
 			return nil, fs.ErrExist
@@ -101,9 +101,8 @@ func OpenBucket(urlStr string, bucketName string, mode OpenMode) (b *Bucket, err
 		if urlStr != bucket.url {
 			return nil, fmt.Errorf("bucket %q already exists at %q, will not open at %q", bucketName, bucket.url, urlStr)
 		}
-		b = bucket.copy()
-		registerBucket(b)
-		return b, nil
+		registerBucket(bucket)
+		return bucket, nil
 
 	}
 

--- a/bucket_api.go
+++ b/bucket_api.go
@@ -60,7 +60,8 @@ func (bucket *Bucket) Close(_ context.Context) {
 	bucket.closed = true
 }
 
-func (bucket *Bucket) _closeAllInstances() {
+// _closeSqliteDB closes the underlying sqlite database and shuts down dcpFeeds. Must have a lock to call this function.
+func (bucket *Bucket) _closeSqliteDB() {
 	if bucket.expTimer != nil {
 		bucket.expTimer.Stop()
 	}
@@ -78,7 +79,7 @@ func (bucket *Bucket) _closeAllInstances() {
 func (bucket *Bucket) CloseAndDelete(ctx context.Context) (err error) {
 	bucket.mutex.Lock()
 	defer bucket.mutex.Unlock()
-	bucket._closeAllInstances()
+	bucket._closeSqliteDB()
 	return deleteBucket(ctx, bucket)
 }
 

--- a/bucket_api.go
+++ b/bucket_api.go
@@ -31,7 +31,7 @@ func (bucket *Bucket) GetURL() string { return bucket.url }
 func (bucket *Bucket) GetName() string { return bucket.name }
 
 // Renames the bucket. This doesn't affect its URL, only the value returned by GetName.
-func (bucket *Bucket) SetName(name string) error {
+func (bucket *Bucket) setName(name string) error {
 	info("Bucket %s is now named %q", bucket, name)
 	_, err := bucket.db().Exec(`UPDATE bucket SET name=?1`, name)
 	if err == nil {
@@ -57,6 +57,10 @@ func (bucket *Bucket) Close(_ context.Context) {
 	bucket.mutex.Lock()
 	defer bucket.mutex.Unlock()
 
+	bucket.closed = true
+}
+
+func (bucket *Bucket) _closeAllInstances() {
 	if bucket.expTimer != nil {
 		bucket.expTimer.Stop()
 	}
@@ -71,16 +75,11 @@ func (bucket *Bucket) Close(_ context.Context) {
 }
 
 // Closes a bucket and deletes its directory and files (unless it's in-memory.)
-func (bucket *Bucket) CloseAndDelete() (err error) {
-	bucket.Close(context.TODO())
-
+func (bucket *Bucket) CloseAndDelete(ctx context.Context) (err error) {
 	bucket.mutex.Lock()
 	defer bucket.mutex.Unlock()
-	if bucket.url != "" {
-		err = DeleteBucketAt(bucket.url)
-		bucket.url = ""
-	}
-	return err
+	bucket._closeAllInstances()
+	return deleteBucket(ctx, bucket)
 }
 
 func (bucket *Bucket) IsSupported(feature sgbucket.BucketStoreFeature) bool {
@@ -349,8 +348,8 @@ func (bucket *Bucket) scheduleExpirationAtOrBefore(exp uint32) {
 	if exp > 0 {
 		bucket.mutex.Lock()
 		defer bucket.mutex.Unlock()
-		if exp < bucket.nextExp || bucket.nextExp == 0 {
-			bucket.nextExp = exp
+		if exp < *bucket.nextExp || *bucket.nextExp == 0 {
+			bucket.nextExp = &exp
 			dur := expDuration(exp)
 			if dur < 0 {
 				dur = 0
@@ -367,7 +366,7 @@ func (bucket *Bucket) scheduleExpirationAtOrBefore(exp uint32) {
 
 func (bucket *Bucket) doExpiration() {
 	bucket.mutex.Lock()
-	bucket.nextExp = 0
+	bucket.nextExp = func(x uint32) *uint32 { return &x }(0)
 	bucket.mutex.Unlock()
 
 	debug("EXP: Running scheduled expiration...")

--- a/bucket_registry.go
+++ b/bucket_registry.go
@@ -13,11 +13,12 @@ import (
 	"sync"
 )
 
-// The bucket registry tracks all open Buckets and refcounts them.
-// The canonical version of the bucket is in the buckets member of the bucketRegistry. This will remain in memory for the following length of time:
-//
+// The bucket registry tracks all open Buckets and refcounts them. This represents a cluster of buckets, one per bucket name. When OpenBucket is called, a Bucket instance is added to bucketRegistry, representing the canonical bucket object. This object will not be removed from the bucket registry until:
+
 // * In Memory bucket: bucket is not deleted until any Bucket's CloseAndDelete is closed.
 // * On disk bucket: bucket is deleted from registry when all there are no open copies of the bucket in memory. Unlike in memory bucket, the bucket will stay persisted on disk to be reopened.
+//
+// Any Buckets returned by OpenBucket will be a copy of the canonical bucket object, which shares pointers to all mutable objects and copies of immutable objects. The difference between the canonical copy of the bucket is the `closed` state, representing when the bucket is no longer writeable. Sharing the data structures allows a single DCP prodcuer and expiry framework.
 
 // bucketRegistry tracks all open buckets
 type bucketRegistry struct {

--- a/bucket_registry_test.go
+++ b/bucket_registry_test.go
@@ -1,0 +1,83 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rosmar
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReuseInMemoryBucket(t *testing.T) {
+	ensureNoLeaks(t)
+	bucketName := strings.ToLower(t.Name())
+	bucket1, err := OpenBucket(InMemoryURL, bucketName, CreateOrOpen)
+	require.NoError(t, err)
+	key := "foo"
+	body := []byte("bar")
+	require.NoError(t, bucket1.DefaultDataStore().Set("foo", 0, nil, body))
+	require.False(t, bucket1.closed)
+	bucket1.Close(testCtx(t))
+	defer func() {
+		assert.NoError(t, bucket1.CloseAndDelete(testCtx(t)))
+		assert.Len(t, getBucketNames(), 0)
+	}()
+
+	require.True(t, bucket1.closed)
+	require.Equal(t, []string{bucketName}, getBucketNames())
+
+	bucket2, err := OpenBucket(InMemoryURL, bucketName, CreateOrOpen)
+	require.NoError(t, err)
+	require.False(t, bucket2.closed)
+	require.Equal(t, []string{bucketName}, getBucketNames())
+	var bucket2Body []byte
+	_, err = bucket2.DefaultDataStore().Get(key, &bucket2Body)
+	require.NoError(t, err)
+	require.Equal(t, body, bucket2Body)
+}
+
+func TestBucketRegistryRefCountPersistentBucket(t *testing.T) {
+	ensureNoLeaks(t)
+
+	bucketName := strings.ToLower(t.Name())
+	bucket, err := OpenBucket(uriFromPath(t.TempDir()+"/"+bucketName), bucketName, CreateOrOpen)
+	require.NoError(t, err)
+	require.Equal(t, []string{bucketName}, getBucketNames())
+	bucket.Close(testCtx(t))
+	require.Len(t, getBucketNames(), 0)
+}
+
+func TestDuplicateBucketNamesDifferentPath(t *testing.T) {
+
+	ensureNoLeaks(t)
+
+	bucketName := strings.ToLower(t.Name())
+	path1 := uriFromPath(t.TempDir() + "/" + bucketName + "1")
+	path2 := uriFromPath(t.TempDir() + "/" + bucketName + "2")
+
+	bucket1, err := OpenBucket(path1, bucketName, CreateOrOpen)
+	require.NoError(t, err)
+	require.Equal(t, []string{bucketName}, getBucketNames())
+
+	bucket2, err := OpenBucket(path2, bucketName, CreateOrOpen)
+	require.ErrorContains(t, err, "already exists")
+	require.Equal(t, []string{bucketName}, getBucketNames())
+
+	bucket1.Close(testCtx(t))
+	require.Len(t, getBucketNames(), 0)
+
+	// Close bucket1, should allow bucket2 to open
+	bucket2, err = OpenBucket(path2, bucketName, CreateOrOpen)
+	require.NoError(t, err)
+	defer bucket2.Close(testCtx(t))
+	require.Equal(t, []string{bucketName}, getBucketNames())
+
+}

--- a/bucket_registry_test.go
+++ b/bucket_registry_test.go
@@ -28,16 +28,16 @@ func TestReuseInMemoryBucket(t *testing.T) {
 	bucket1.Close(testCtx(t))
 	defer func() {
 		assert.NoError(t, bucket1.CloseAndDelete(testCtx(t)))
-		assert.Len(t, getBucketNames(), 0)
+		assert.Len(t, GetBucketNames(), 0)
 	}()
 
 	require.True(t, bucket1.closed)
-	require.Equal(t, []string{bucketName}, getBucketNames())
+	require.Equal(t, []string{bucketName}, GetBucketNames())
 
 	bucket2, err := OpenBucket(InMemoryURL, bucketName, CreateOrOpen)
 	require.NoError(t, err)
 	require.False(t, bucket2.closed)
-	require.Equal(t, []string{bucketName}, getBucketNames())
+	require.Equal(t, []string{bucketName}, GetBucketNames())
 	var bucket2Body []byte
 	_, err = bucket2.DefaultDataStore().Get(key, &bucket2Body)
 	require.NoError(t, err)
@@ -50,9 +50,9 @@ func TestBucketRegistryRefCountPersistentBucket(t *testing.T) {
 	bucketName := strings.ToLower(t.Name())
 	bucket, err := OpenBucket(uriFromPath(t.TempDir()+"/"+bucketName), bucketName, CreateOrOpen)
 	require.NoError(t, err)
-	require.Equal(t, []string{bucketName}, getBucketNames())
+	require.Equal(t, []string{bucketName}, GetBucketNames())
 	bucket.Close(testCtx(t))
-	require.Len(t, getBucketNames(), 0)
+	require.Len(t, GetBucketNames(), 0)
 }
 
 func TestDuplicateBucketNamesDifferentPath(t *testing.T) {
@@ -65,19 +65,19 @@ func TestDuplicateBucketNamesDifferentPath(t *testing.T) {
 
 	bucket1, err := OpenBucket(path1, bucketName, CreateOrOpen)
 	require.NoError(t, err)
-	require.Equal(t, []string{bucketName}, getBucketNames())
+	require.Equal(t, []string{bucketName}, GetBucketNames())
 
 	bucket2, err := OpenBucket(path2, bucketName, CreateOrOpen)
 	require.ErrorContains(t, err, "already exists")
-	require.Equal(t, []string{bucketName}, getBucketNames())
+	require.Equal(t, []string{bucketName}, GetBucketNames())
 
 	bucket1.Close(testCtx(t))
-	require.Len(t, getBucketNames(), 0)
+	require.Len(t, GetBucketNames(), 0)
 
 	// Close bucket1, should allow bucket2 to open
 	bucket2, err = OpenBucket(path2, bucketName, CreateOrOpen)
 	require.NoError(t, err)
 	defer bucket2.Close(testCtx(t))
-	require.Equal(t, []string{bucketName}, getBucketNames())
+	require.Equal(t, []string{bucketName}, GetBucketNames())
 
 }

--- a/collection.go
+++ b/collection.go
@@ -30,7 +30,6 @@ type Collection struct {
 	bucket                     *Bucket
 	id                         CollectionID // Row ID in collections table; public ID + 1
 	mutex                      sync.Mutex
-	feeds                      []*dcpFeed
 	viewCache                  map[viewKey]*rosmarView
 }
 

--- a/collection_test.go
+++ b/collection_test.go
@@ -455,7 +455,7 @@ func addToCollection(t *testing.T, coll sgbucket.DataStore, key string, exp uint
 }
 
 func ensureNoLeaks(t *testing.T) {
-	t.Cleanup(func() { assert.Len(t, getBucketNames(), 0) })
+	t.Cleanup(func() { assert.Len(t, GetBucketNames(), 0) })
 	ensureNoLeakedFeeds(t)
 }
 

--- a/collection_test.go
+++ b/collection_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestDeleteThenAdd(t *testing.T) {
-	ensureNoLeakedFeeds(t)
+	ensureNoLeaks(t)
 	coll := makeTestBucket(t).DefaultDataStore()
 
 	var value interface{}
@@ -41,7 +41,7 @@ func TestDeleteThenAdd(t *testing.T) {
 }
 
 func TestIncr(t *testing.T) {
-	ensureNoLeakedFeeds(t)
+	ensureNoLeaks(t)
 	coll := makeTestBucket(t).DefaultDataStore()
 	count, err := coll.Incr("count1", 1, 100, 0)
 	assert.NoError(t, err, "Incr")
@@ -62,7 +62,7 @@ func TestIncr(t *testing.T) {
 
 // Spawns 1000 goroutines that 'simultaneously' use Incr to increment the same counter by 1.
 func TestIncrAtomic(t *testing.T) {
-	ensureNoLeakedFeeds(t)
+	ensureNoLeaks(t)
 	coll := makeTestBucket(t).DefaultDataStore()
 	var waiters sync.WaitGroup
 	numIncrements := 5
@@ -82,7 +82,7 @@ func TestIncrAtomic(t *testing.T) {
 }
 
 func TestAppend(t *testing.T) {
-	ensureNoLeakedFeeds(t)
+	ensureNoLeaks(t)
 	coll := makeTestBucket(t).DefaultDataStore()
 
 	exists, err := coll.Exists("key")
@@ -105,7 +105,7 @@ func TestAppend(t *testing.T) {
 }
 
 func TestGets(t *testing.T) {
-	ensureNoLeakedFeeds(t)
+	ensureNoLeaks(t)
 
 	coll := makeTestBucket(t).DefaultDataStore()
 
@@ -181,7 +181,7 @@ func TestEvalSubdocPaths(t *testing.T) {
 }
 
 func initSubDocTest(t *testing.T) sgbucket.DataStore {
-	ensureNoLeakedFeeds(t)
+	ensureNoLeaks(t)
 
 	coll := makeTestBucket(t).DefaultDataStore()
 	require.True(t, coll.IsSupported(sgbucket.BucketStoreFeatureSubdocOperations))
@@ -260,7 +260,7 @@ func TestInsertSubDoc(t *testing.T) {
 }
 
 func TestWriteCas(t *testing.T) {
-	ensureNoLeakedFeeds(t)
+	ensureNoLeaks(t)
 
 	coll := makeTestBucket(t).DefaultDataStore()
 
@@ -336,7 +336,7 @@ func TestWriteCas(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
-	ensureNoLeakedFeeds(t)
+	ensureNoLeaks(t)
 
 	coll := makeTestBucket(t).DefaultDataStore()
 
@@ -452,6 +452,11 @@ func addToCollection(t *testing.T, coll sgbucket.DataStore, key string, exp uint
 	added, err := coll.Add(key, exp, value)
 	require.NoError(t, err)
 	require.True(t, added, "Expected doc to be added")
+}
+
+func ensureNoLeaks(t *testing.T) {
+	t.Cleanup(func() { assert.Len(t, getBucketNames(), 0) })
+	ensureNoLeakedFeeds(t)
 }
 
 func ensureNoLeakedFeeds(t *testing.T) {

--- a/feeds_test.go
+++ b/feeds_test.go
@@ -11,6 +11,7 @@ package rosmar
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -74,7 +75,7 @@ func TestMutations(t *testing.T) {
 	e.TimeReceived = time.Time{}
 	assert.Equal(t, sgbucket.FeedEvent{Opcode: sgbucket.FeedOpDeletion, Key: []byte("eskimo"), Cas: 7, DataType: sgbucket.FeedDataTypeRaw}, e)
 
-	bucket.Close(testCtx(t))
+	require.NoError(t, bucket.CloseAndDelete(testCtx(t)))
 
 	_, ok := <-doneChan
 	assert.False(t, ok)
@@ -190,7 +191,7 @@ func TestCrossBucketEvents(t *testing.T) {
 	addToCollection(t, c, "charlie", 0, "C")
 
 	// Open a 2nd bucket on the same file, to receive events:
-	bucket2, err := OpenBucket(bucket.url, ReOpenExisting)
+	bucket2, err := OpenBucket(bucket.url, strings.ToLower(t.Name()), ReOpenExisting)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		bucket2.Close(testCtx(t))
@@ -212,7 +213,7 @@ func TestCrossBucketEvents(t *testing.T) {
 	readExpectedEventsDEF(t, events2, 4)
 
 	bucket.Close(testCtx(t))
-	bucket2.Close(testCtx(t))
+	require.NoError(t, bucket2.CloseAndDelete(testCtx(t)))
 
 	_, ok := <-doneChan
 	assert.False(t, ok)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/couchbaselabs/rosmar
 go 1.19
 
 require (
-	github.com/couchbase/sg-bucket v0.0.0-20231108134134-545ec7bf1a9e
+	github.com/couchbase/sg-bucket v0.0.0-20231116231254-16c1ad8b2483
 	github.com/google/uuid v1.3.0
 	github.com/mattn/go-sqlite3 v1.14.17
 	github.com/stretchr/testify v1.8.4

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,10 @@ module github.com/couchbaselabs/rosmar
 go 1.19
 
 require (
-	github.com/couchbase/sg-bucket v0.0.0-20231003103030-627c70e18148
+	github.com/couchbase/sg-bucket v0.0.0-20231108134134-545ec7bf1a9e
 	github.com/google/uuid v1.3.0
 	github.com/mattn/go-sqlite3 v1.14.17
 	github.com/stretchr/testify v1.8.4
-	golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/couchbase/sg-bucket v0.0.0-20231003103030-627c70e18148 h1:9E3u0yA+be219iLLOjuYgagOfM7UqtZ0YIhMXysJVKs=
-github.com/couchbase/sg-bucket v0.0.0-20231003103030-627c70e18148/go.mod h1:hy6J0RXx/Ry+5EiI8VVMetsVfBXQq5/djQLbvfRau0k=
+github.com/couchbase/sg-bucket v0.0.0-20231108134134-545ec7bf1a9e h1:IFv4HcdpvKFEaaszv6f1WcEbWmU276rFzOaJgarw5gw=
+github.com/couchbase/sg-bucket v0.0.0-20231108134134-545ec7bf1a9e/go.mod h1:hy6J0RXx/Ry+5EiI8VVMetsVfBXQq5/djQLbvfRau0k=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -17,8 +17,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b h1:r+vk0EmXNmekl0S0BascoeeoHk/L7wmaW2QF90K+kYI=
-golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/text v0.11.0 h1:LAntKIrcmeSKERyiOh0XMV39LXS8IE9UL2yP7+f5ij4=
 golang.org/x/text v0.11.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/couchbase/sg-bucket v0.0.0-20231108134134-545ec7bf1a9e h1:IFv4HcdpvKFEaaszv6f1WcEbWmU276rFzOaJgarw5gw=
-github.com/couchbase/sg-bucket v0.0.0-20231108134134-545ec7bf1a9e/go.mod h1:hy6J0RXx/Ry+5EiI8VVMetsVfBXQq5/djQLbvfRau0k=
+github.com/couchbase/sg-bucket v0.0.0-20231116231254-16c1ad8b2483 h1:K6y82On0A3coA+GwW+HGKIwpCpca6ZSvTAJwwTmzCrg=
+github.com/couchbase/sg-bucket v0.0.0-20231116231254-16c1ad8b2483/go.mod h1:hy6J0RXx/Ry+5EiI8VVMetsVfBXQq5/djQLbvfRau0k=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
- in memory buckets will now live for the lifecycle of the program until Bucket.CloseAndDelete is called. This facilitates bucket closing without removing the data, which is a common use in Sync Gateway tests that use persistent config to update database configuration.
- When a bucket is first created, a copy is stored in the bucket registry, and this is never closed until:
  	- in memory: CloseAndDelete is called
	- on disk: Close is called to bring refcount of buckets to 0
- force bucket name to be defined, and do not let multiple copies of a persistent bucket to be opened if they are different paths. Note, this is a blunt instrument, and it is indiscriminate to path manipulations. It does path matching on lexography, not normalized paths. The idea is to be safer. Sync Gateway is not architected to support multiple buckets with the same name that do not have the same backing data.

Implementation:

The global state of a bucket is representative of two things:

- *sql.DB represnting the underlying sqlite connection
- dcpFeeds for each connection that exists

The sql.DB connection can be opened multiple times on the same path, and this was the original implementation of rosmar. However, it can't be opened multiple times for in memory files except via cache=shared query parameter to sqlite3_open. This ended up causing behavior that I didn't understand, and is not typically a supported in sqlite, since multiple databases are managed with a WAL when on disk.

DCP feeds in rosmar work by having pushing events on a CUD operation to a queue, which can be read by any running feeds. Instead of having separate feeds for each copy of Bucket and publishing them via `bucketsAtUrl`, we now only have a single canonical set of bucket feeds. Moved this field from a Collection to Bucket. This addresses https://issues.couchbase.com/browse/CBG-3540

Whether a bucket is open or closed is controlled by Bucket._db() that is called by any CRUD operations. A Collection has a pointer to its parent bucket. Each Bucket opened now will create a Collection dynamically, but these share pointers to the cached in memory versions.

Depends on https://github.com/couchbase/sg-bucket/pull/110