### PR TITLE
CBG-3271 make sure expiration works on a closed bucket

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -357,22 +357,26 @@ func (c *Collection) WriteCas(key string, flags int, exp Exp, cas CAS, val any, 
 	return
 }
 
+// Remove creates a document tombstone. It removes the document's value and user xattrs.
 func (c *Collection) Remove(key string, cas CAS) (casOut CAS, err error) {
 	traceEnter("Remove", "%q, 0x%x", key, cas)
-	casOut, err = c.remove(key, &cas)
+	casOut, err = c.remove(key, &cas, checkBucketClosed)
 	traceExit("Remove", err, "0x%x", casOut)
 	return
 }
 
+// Delete creates a document tombstone. It removes the document's value and user xattrs. Equivalent to Remove without a CAS check.
 func (c *Collection) Delete(key string) (err error) {
 	traceEnter("Delete", "%q", key)
-	_, err = c.remove(key, nil)
+	_, err = c.remove(key, nil, checkBucketClosed)
 	traceExit("Delete", err, "ok")
 	return err
 }
 
-func (c *Collection) remove(key string, ifCas *CAS) (casOut CAS, err error) {
-	err = c.withNewCas(func(txn *sql.Tx, newCas CAS) (e *event, err error) {
+// remove creates a document tombstone. It removes the document's value and user xattrs. checkClosed will allow removing the document even the bucket instance is "closed".
+func (c *Collection) remove(key string, ifCas *CAS, checkClosed bucketClosedCheck) (casOut CAS, err error) {
+	fmt.Println("remove", checkClosed)
+	err = c.withNewCasAndBucketClosedCheck(func(txn *sql.Tx, newCas CAS) (e *event, err error) {
 		// Get the doc, possibly checking cas:
 		var cas CAS
 		var rawXattrs []byte
@@ -416,7 +420,7 @@ func (c *Collection) remove(key string, ifCas *CAS) (casOut CAS, err error) {
 		}
 		casOut = newCas
 		return
-	})
+	}, checkClosed)
 	return
 }
 
@@ -518,14 +522,14 @@ func (c *Collection) IsSupported(feature sgbucket.BucketStoreFeature) bool {
 
 //////// EXPIRATION
 
-// Immediately deletes all expired documents in this collection.
-func (c *Collection) ExpireDocuments() (count int64, err error) {
-	traceEnter("ExpireDocuments", "")
-	defer func() { traceExit("ExpireDocuments", err, "%d", count) }()
+// _expireDocuments immediately deletes all expired documents in this collection.
+func (c *Collection) expireDocuments() (count int64, err error) {
+	traceEnter("_expireDocuments", "")
+	defer func() { traceExit("_expireDocuments", err, "%d", count) }()
 
 	// First find all the expired docs and collect their keys:
 	exp := nowAsExpiry()
-	rows, err := c.db().Query(`SELECT key FROM documents
+	rows, err := c.bucket._underlyingDB().Query(`SELECT key FROM documents
 								WHERE collection = ?1 AND exp > 0 AND exp <= ?2`, c.id, exp)
 	if err != nil {
 		return
@@ -546,8 +550,10 @@ func (c *Collection) ExpireDocuments() (count int64, err error) {
 	// will get its own db connection, and if the db only supports one connection (i.e. in-memory)
 	// having both queries active would deadlock.)
 	for _, key := range keys {
-		if c.Delete(key) == nil {
+		_, err = c.remove(key, nil, skipCheckBucketClosed)
+		if err == nil {
 			count++
+		} else {
 		}
 	}
 	return
@@ -581,6 +587,11 @@ func (c *Collection) setLastCas(txn *sql.Tx, cas CAS) (err error) {
 // Runs a function within a SQLite transaction, passing it a new CAS to assign to the
 // document being modified. The function returns an event to be posted.
 func (c *Collection) withNewCas(fn func(txn *sql.Tx, newCas CAS) (*event, error)) error {
+	return c.withNewCasAndBucketClosedCheck(fn, checkBucketClosed)
+}
+
+// withNewCasAndBucketClosedCheck runs a function within a SQLite transaction like withNewCas. This allows the caller to bypass the bucket closed status, suitable for functions that need to run on the underlying bucket object.
+func (c *Collection) withNewCasAndBucketClosedCheck(fn func(txn *sql.Tx, newCas CAS) (*event, error), checkClosed bucketClosedCheck) error {
 	var e *event
 	err := c.bucket.inTransaction(func(txn *sql.Tx) error {
 		newCas, err := c.bucket.getLastCas(txn)
@@ -592,7 +603,7 @@ func (c *Collection) withNewCas(fn func(txn *sql.Tx, newCas CAS) (*event, error)
 			}
 		}
 		return err
-	})
+	}, checkClosed)
 	if err == nil && e != nil {
 		c.postNewEvent(e)
 	}

--- a/designdoc.go
+++ b/designdoc.go
@@ -103,7 +103,7 @@ func (c *Collection) PutDDoc(_ context.Context, designDoc string, ddoc *sgbucket
 		}
 		c.forgetCachedViews(designDoc)
 		return nil
-	})
+	}, checkBucketClosed)
 	traceExit("PutDDoc", err, "ok")
 	return err
 }
@@ -121,7 +121,7 @@ func (c *Collection) DeleteDDoc(designDoc string) error {
 			}
 		}
 		return err
-	})
+	}, checkBucketClosed)
 	traceExit("DeleteDDoc", err, "ok")
 	return err
 }

--- a/expiration_manager.go
+++ b/expiration_manager.go
@@ -1,0 +1,104 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rosmar
+
+import (
+	"sync"
+	"time"
+)
+
+// expirationManager handles expiration for a given bucket. It stores a timer which will call expirationFunc to delete documents. The value of when the timer
+type expirationManager struct {
+	mutex          *sync.Mutex // mutex for synchronized access to expirationManager
+	timer          *time.Timer // Schedules expiration of docs
+	nextExp        *uint32     // Timestamp when expTimer will run (0 if never)
+	expirationFunc func()      // Function to call when timer expires
+}
+
+func newExpirationManager(expiractionFunc func()) *expirationManager {
+	var nextExp uint32
+	return &expirationManager{
+		mutex:          &sync.Mutex{},
+		nextExp:        &nextExp,
+		expirationFunc: expiractionFunc,
+	}
+}
+
+// stop stops existing timers and waits for any expiration processes to complete
+func (e *expirationManager) stop() {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+	if e.timer != nil {
+		e.timer.Stop()
+	}
+}
+
+// _getNext returns the next expiration time, 0 if there is no scheduled expiration.
+func (e *expirationManager) _getNext() uint32 {
+	return *e.nextExp
+}
+
+// setNext sets the next expiration time and schedules an expiration to occur after that time.
+func (e *expirationManager) setNext(exp uint32) {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+	e._setNext(exp)
+}
+
+// _clearNext clears the next expiration time.
+func (e *expirationManager) _clearNext() {
+	var exp uint32
+	e.nextExp = &exp
+}
+
+// setNext sets the next expiration time and schedules an expiration to occur after that time. Requires caller to have acquired mutex.
+func (e *expirationManager) _setNext(exp uint32) {
+	info("_setNext ", exp)
+	e.nextExp = &exp
+	if exp == 0 {
+		e.timer = nil
+		return
+	}
+	dur := expDuration(exp)
+	if dur < 0 {
+		dur = 0
+	}
+	debug("EXP: Scheduling in %s", dur)
+	if e.timer == nil {
+		e.timer = time.AfterFunc(dur, e.runExpiry)
+	} else {
+		e.timer.Reset(dur)
+	}
+}
+
+// scheduleExpirationAtOrBefore schedules the next expiration of documents to occur, from the minimum expiration value in the bucket.
+func (e *expirationManager) scheduleExpirationAtOrBefore(exp uint32) {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+	e._scheduleExpirationAtOrBefore(exp)
+}
+
+// _scheduleExpirationAtOrBefore schedules the next expiration of documents to occur, from the minimum expiration value in the bucket. Requires the mutext to be held.
+func (e *expirationManager) _scheduleExpirationAtOrBefore(exp uint32) {
+	if exp == 0 {
+		return
+	}
+	currentNextExp := e._getNext()
+	// if zero will unset the timer.
+	if currentNextExp == 0 || exp < currentNextExp {
+		e._setNext(exp)
+	}
+}
+
+// runExpiry is called when the timer expires. It calls the expirationFunc and then reschedules the timer if necessary.
+func (e *expirationManager) runExpiry() {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+	e.expirationFunc()
+}

--- a/feeds.go
+++ b/feeds.go
@@ -168,7 +168,7 @@ func (c *Collection) postNewEvent(e *event) {
 	feedEvent := e.asFeedEvent()
 
 	c.postEvent(feedEvent)
-	c.bucket.scheduleExpirationAtOrBefore(e.exp)
+	c.bucket.expManager._scheduleExpirationAtOrBefore(e.exp)
 
 	/*
 		// Tell collections of other buckets on the same db file to post the event too:

--- a/views.go
+++ b/views.go
@@ -306,7 +306,7 @@ func (c *Collection) updateView(ctx context.Context, designDoc string, viewName 
 			view.lastCas = latestCas
 		}
 		return err
-	})
+	}, checkBucketClosed)
 	return view, err
 }
 


### PR DESCRIPTION
Make sure the following works:

- open bucket
- write doc with expiry of 1 sec
- close bucket
- wait more than 1 sec

The doc should expire, because another caller can re-open foo, and would expect the document to be deleted. This is akin to metadata purge interval.

Implementation:

- Abstracted ExpirationManager into a separate struct / file for readability.
- ExpirationManager exists on every Bucket, since expiration is set based on a CRUD operation, which could occur on any copy of the bucket.
- The functions for expiration use a new function _underlyingDB which returns a queryable object that is never closed.

Questions:

I really don't like `TestExpirationAfterClose` because it adds a `Sleep` to ensure it doesn't panic, and it doubles the test time, which is mostly slow already because `TestExpiration` has a 3 second sleep. I can't think of a good way to shorten either test, but I think `TestExpirationAfterClose` might be removed for non development since it repros pretty easily in sync gateway CI.