### PR TITLE
CBG-3392 match CAS checks for xattrs like CBS does

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -27,7 +27,9 @@ CREATE TABLE documents (
 	xattrs 		blob, 				/* xattrs in JSON, else null */
 	isJSON 		integer default true,
 	value 		blob, 				/* document body, usually JSON; null if deleted */
+	tombstone 	integer default 0,
 	UNIQUE (collection, key) );
+
 CREATE INDEX docs_cas ON documents (collection, cas);
 CREATE INDEX docs_exp ON documents (collection, exp) WHERE exp > 0;
 


### PR DESCRIPTION
This matches CBS behavior and allows all SG tests to pass.

I found the logic in `checkCASXattr` to be really confusing and I'm not sure how to make it easier.

Formerly, a document was declared a tombstone based on whether it has nil document body. However, having a nil document body is a valid state for a document, so I added field to determine whether it is a tombstone. I didn't write a schema migration to add this field since we have no released version of SG that can use a persistent rosmar database.

I switched some bitflags to an options struct to make it easier to read and more idiomatic in go, rather than add two new flags.

This passes all tests in Sync Gateway, including the ones that are currently skipped.

