### PR TITLE
Close sqliteDB but do not set to nil

### DIFF
--- a/bucket_api.go
+++ b/bucket_api.go
@@ -67,7 +67,6 @@ func (bucket *Bucket) _closeSqliteDB() {
 	}
 	if bucket.sqliteDB != nil {
 		bucket.sqliteDB.Close()
-		bucket.sqliteDB = nil
 		bucket.collections = nil
 	}
 }


### PR DESCRIPTION
We use closed variable to test if it open when calling `db()`, so we no longer need to set `sqliteDB = closed` as per https://github.com/couchbaselabs/rosmar/commit/adb4806d011edcca8dd5cb74297c8b35083cf785

This should fix a panic if there is a sql.DB in use while this is running, as per this example stack traces. These stack traces come when goroutines outlive the `Bucket` object - after the `TestBucket` has already been returned to the bucket pool, so we do not know which test they belong to.

Arguably these are bugs in Sync Gateway since we should wait for finish of all goroutines before we close the bucket. If the bucket is closed in action, it should return this error https://cs.opensource.google/go/go/+/refs/tags/go1.21.4:src/database/sql/sql.go;l=1270 - but this is not a catchable error. I _think_ this is okay if these statements return an error since they are part of goroutines where we are not expecting an error.

```
2023/11/29 14:10:49 Unexpected panic: runtime error: invalid memory address or nil pointer dereference - stopping process
goroutine 24593 [running]:
runtime/debug.Stack()
	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.21.4/src/runtime/debug/stack.go:24 +0x67
github.com/couchbase/sync_gateway/base.FatalPanicHandler()
	/home/ec2-user/workspace/Sync_Gateway_Pipeline_master/base/util.go:1440 +0x98
panic({0x1c26300?, 0x3ae05e0?})
	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.21.4/src/runtime/panic.go:920 +0x270
database/sql.(*DB).conn(0x0, {0x2f88c20, 0x4bfce80}, 0x1)
	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.21.4/src/database/sql/sql.go:1282 +0x52
database/sql.(*DB).query(0xc000e5a72c?, {0x2f88c20, 0x4bfce80}, {0x1e1a816, 0x2b}, {0xc000f242c0, 0x1, 0x1}, 0xa0?)
	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.21.4/src/database/sql/sql.go:1721 +0x8e
database/sql.(*DB).QueryContext.func1(0x0?)
	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.21.4/src/database/sql/sql.go:1704 +0xd0
database/sql.(*DB).retry(0x3000000?, 0xc0015309a8)
	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.21.4/src/database/sql/sql.go:1538 +0x4b
database/sql.(*DB).QueryContext(0x0, {0x2f88c20, 0x4bfce80}, {0x1e1a816, 0x2b}, {0xc000f242c0, 0x1, 0x1})
	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.21.4/src/database/sql/sql.go:1703 +0x133
database/sql.(*DB).QueryRowContext(...)
	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.21.4/src/database/sql/sql.go:1804
database/sql.(*DB).QueryRow(0x1000000?, {0x1e1a816, 0x2b}, {0xc000f242c0, 0x1, 0x1})
	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.21.4/src/database/sql/sql.go:1818 +0x89
github.com/couchbaselabs/rosmar.(*Collection).getLastCas(0xc000e5a700, {0x2f861e8, 0x0})
	/home/ec2-user/go/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20231129014059-5c7f6a7d7526/collection.go:581 +0xf6
github.com/couchbaselabs/rosmar.(*Collection).view(0xc000e5a700, {0x2f88cd0?, 0xc000d32b70}, {0xc0011bb4f0, 0x10}, {0x1dd0075, 0x8}, 0xc0043f9bc0)
	/home/ec2-user/go/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20231129014059-5c7f6a7d7526/views.go:85 +0x1d8
github.com/couchbaselabs/rosmar.(*Collection).ViewQuery(0xc001278000?, {0x2f88cd0, 0xc000d32b70}, {0xc0011bb4f0, 0x10}, {0x1dd0075, 0x8}, 0xc0043f9bc0)
	/home/ec2-user/go/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20231129014059-5c7f6a7d7526/views.go:49 +0x258
github.com/couchbase/sync_gateway/base.(*LeakyDataStore).ViewQuery(0xc000d66840, {0x2f88cd0, 0xc000d32b70}, {0xc0011bb4f0, 0x10}, {0x1dd0075, 0x8}, 0x42921a?)
	/home/ec2-user/workspace/Sync_Gateway_Pipeline_master/base/leaky_datastore.go:230 +0x19e
github.com/couchbase/sync_gateway/base.(*LeakyDataStore).ViewQuery(0xc000d66870, {0x2f88cd0, 0xc000d32b70}, {0xc0011bb4f0, 0x10}, {0x1dd0075, 0x8}, 0x42567e?)
	/home/ec2-user/workspace/Sync_Gateway_Pipeline_master/base/leaky_datastore.go:230 +0x19e
github.com/couchbase/sync_gateway/db.(*DatabaseContext).ViewQueryWithStats(0xc000718600, {0x2f88cd0, 0xc000d32b70}, {0x2f98d38, 0xc000d66870}, {0xc0011bb4f0, 0x10}, {0x1dd0075, 0x8}, 0xc0043f9bc0)
	/home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/query.go:417 +0x4fa
github.com/couchbase/sync_gateway/db.(*DatabaseCollection).QueryChannels(0xc0037d4360, {0x2f88cd0, 0xc000d32b70}, {0x3b25cb0, 0x1}, 0xc0026c1600?, 0x2, 0x1388, 0x1?)
	/home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/query.go:496 +0x798
github.com/couchbase/sync_gateway/db.(*DatabaseCollection).getChangesInChannelFromQuery(0xc0037d4360, {0x2f88cd0, 0xc000d32b70}, {0x3b25cb0, 0x1}, 0x1, 0x2, 0x1388, 0x0)
	/home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/changes_view.go:109 +0x5dc
github.com/couchbase/sync_gateway/db.(*singleChannelCacheImpl).GetChanges(0xc00151aa80, {0x2f88cd0, 0xc000d32b70}, {{0x0, 0x0, 0x0}, 0x1388, 0x0, 0x0, 0x1, ...})
	/home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/channel_cache_single.go:417 +0xc16
github.com/couchbase/sync_gateway/db.(*DatabaseCollectionWithUser).changesFeed.func1()
	/home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/changes.go:417 +0x4b0
created by github.com/couchbase/sync_gateway/db.(*DatabaseCollectionWithUser).changesFeed in goroutine 24591
	/home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/changes.go:398 +0x5f2
```

or https://issues.couchbase.com/browse/CBG-3090 here:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1009fa532]

goroutine 19440 [running]:
database/sql.(*DB).conn(0x0, {0x102bc6b60, 0x104635240}, 0x1)
	/Users/couchbase/cbdeps/go1.21.4/src/database/sql/sql.go:1282 +0x52
database/sql.(*DB).query(0x10000bdfd?, {0x102bc6b60, 0x104635240}, {0x101a78956, 0x3d}, {0xc00485e340, 0x2, 0x2}, 0x0?)
	/Users/couchbase/cbdeps/go1.21.4/src/database/sql/sql.go:1721 +0x8e
database/sql.(*DB).QueryContext.func1(0xf1?)
	/Users/couchbase/cbdeps/go1.21.4/src/database/sql/sql.go:1704 +0xd0
database/sql.(*DB).retry(0xc0042bd830?, 0xc0042bd7c8)
	/Users/couchbase/cbdeps/go1.21.4/src/database/sql/sql.go:1538 +0x4b
database/sql.(*DB).QueryContext(0x0, {0x102bc6b60, 0x104635240}, {0x101a78956, 0x3d}, {0xc00485e340, 0x2, 0x2})
	/Users/couchbase/cbdeps/go1.21.4/src/database/sql/sql.go:1703 +0x133
database/sql.(*DB).QueryRowContext(...)
	/Users/couchbase/cbdeps/go1.21.4/src/database/sql/sql.go:1804
database/sql.(*DB).QueryRow(0xc0037df800?, {0x101a78956, 0x3d}, {0xc00485e340, 0x2, 0x2})
	/Users/couchbase/cbdeps/go1.21.4/src/database/sql/sql.go:1818 +0x89
github.com/couchbaselabs/rosmar.(*Collection).getRaw(0xc003bdc340, {0x102bc4040, 0x0}, {0xc0037df800, 0x23})
	/Users/couchbase/workspace/sgw-unix-build/3.2.0/enterprise/godeps/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20231129014059-5c7f6a7d7526/collection.go:113 +0x18c
github.com/couchbaselabs/rosmar.(*Collection).GetRaw(0xc003bdc340, {0xc0037df800, 0x23})
	/Users/couchbase/workspace/sgw-unix-build/3.2.0/enterprise/godeps/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20231129014059-5c7f6a7d7526/collection.go:99 +0x12f
github.com/couchbase/sync_gateway/base.(*LeakyDataStore).GetRaw(0xc007ad5a40, {0xc0037df800, 0x23})
	/Users/couchbase/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/base/leaky_datastore.go:97 +0xe7
github.com/couchbase/sync_gateway/base.(*LeakyDataStore).GetRaw(0xc007ad5a70, {0xc0037df800, 0x23})
	/Users/couchbase/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/base/leaky_datastore.go:97 +0xe7
github.com/couchbase/sync_gateway/base.(*LeakyDataStore).GetRaw(0xc007ad5aa0, {0xc0037df800, 0x23})
	/Users/couchbase/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/base/leaky_datastore.go:97 +0xe7
github.com/couchbase/sync_gateway/db.getWithTouch({0x102bd8618, 0xc007ad5aa0}, {0xc0037df800, 0x23}, 0x0)
	/Users/couchbase/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/db/special_docs.go:45 +0x87
github.com/couchbase/sync_gateway/db.getLocalStatusDoc({0x102bc6c48, 0xc007e15cc0}, {0x102bd8618, 0xc007ad5aa0}, {0xc0037df800, 0x23})
	/Users/couchbase/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/db/active_replicator_common.go:390 +0x7e
github.com/couchbase/sync_gateway/db.setLocalStatus({0x102bc6c48, 0xc007e15cc0}, {0x102bd8618, 0xc007ad5aa0}, {0xc0037df800, 0x23}, 0xc000175b00, 0x10004f547?)
	/Users/couchbase/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/db/active_replicator_common.go:420 +0x134
github.com/couchbase/sync_gateway/db.(*activeReplicatorCommon)._publishStatus(0xc007a48420)
	/Users/couchbase/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/db/active_replicator_common.go:361 +0x213
github.com/couchbase/sync_gateway/db.(*activeReplicatorCommon).startStatusReporter.func1.1(0xc007a48420)
	/Users/couchbase/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/db/active_replicator_common.go:377 +0x85
github.com/couchbase/sync_gateway/db.(*activeReplicatorCommon).startStatusReporter.func1({0x102bc6c48, 0xc007e15cc0})
	/Users/couchbase/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/db/active_replicator_common.go:378 +0xeb
created by github.com/couchbase/sync_gateway/db.(*activeReplicatorCommon).startStatusReporter in goroutine 19291
	/Users/couchbase/workspace/sgw-unix-build/3.2.0/enterprise/sync_gateway/db/active_replicator_common.go:368 +0x167
```

I've run this a handful of times through jenkins with a T3A.XLarge where we reproduced some of these failures, but I can't be sure this is 100% correct.