### PR TITLE
CBG-3627 implement hlc for each bucket

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -42,6 +42,7 @@ type Bucket struct {
 	serial          uint32         // Serial number for logging
 	inMemory        bool           // True if it's an in-memory database
 	closed          bool           // represents state when it is closed
+	hlc             *hybridLogicalClock
 }
 
 type collectionsMap = map[sgbucket.DataStoreNameImpl]*Collection
@@ -194,6 +195,8 @@ func OpenBucket(urlStr string, bucketName string, mode OpenMode) (b *Bucket, err
 	if err != nil {
 		return nil, err
 	}
+
+	bucket.hlc = NewHybridLogicalClock(bucket.getLastTimestamp())
 
 	exists, bucketCopy := registerBucket(bucket)
 	// someone else beat registered the bucket in the registry, that's OK we'll close ours
@@ -385,6 +388,7 @@ func (b *Bucket) copy() *Bucket {
 		expManager:      b.expManager,
 		serial:          b.serial,
 		inMemory:        b.inMemory,
+		hlc:             b.hlc,
 	}
 	return r
 }

--- a/hlc.go
+++ b/hlc.go
@@ -48,12 +48,12 @@ func NewHybridLogicalClock(lastTime timestamp) *hybridLogicalClock {
 func (c *hybridLogicalClock) Now() timestamp {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
-	physicalTime := c.clock.getTime() & 0xFFFF
+	physicalTime := c.clock.getTime() &^ 0xFFFF // round to 48 bits to allow counter at end
 	if c.highestTime >= physicalTime {
 		c.counter++
 	} else {
 		c.counter = 0
 		c.highestTime = physicalTime
 	}
-	return timestamp((c.highestTime << 16) | uint64(c.counter))
+	return timestamp(c.highestTime | uint64(c.counter))
 }

--- a/hlc.go
+++ b/hlc.go
@@ -18,7 +18,6 @@ type timestamp uint64
 // hybridLogicalClock is a hybrid logical clock implementation for rosmar that produces timestamps that will always be increasing regardless of clock changes.
 type hybridLogicalClock struct {
 	clock       clock
-	counter     uint16
 	highestTime uint64
 	mutex       sync.Mutex
 }
@@ -48,12 +47,11 @@ func NewHybridLogicalClock(lastTime timestamp) *hybridLogicalClock {
 func (c *hybridLogicalClock) Now() timestamp {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
-	physicalTime := c.clock.getTime() &^ 0xFFFF // round to 48 bits to allow counter at end
+	physicalTime := c.clock.getTime() &^ 0xFFFF // round to 48 bits
 	if c.highestTime >= physicalTime {
-		c.counter++
+		c.highestTime++
 	} else {
-		c.counter = 0
 		c.highestTime = physicalTime
 	}
-	return timestamp(c.highestTime | uint64(c.counter))
+	return timestamp(c.highestTime)
 }

--- a/hlc.go
+++ b/hlc.go
@@ -1,0 +1,59 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rosmar
+
+import (
+	"sync"
+	"time"
+)
+
+type timestamp uint64
+
+// hybridLogicalClock is a hybrid logical clock implementation for rosmar that produces timestamps that will always be increasing regardless of clock changes.
+type hybridLogicalClock struct {
+	clock       clock
+	counter     timestamp
+	highestTime timestamp
+	mutex       sync.Mutex
+}
+
+// clock interface is used to abstract the system clock for testing purposes.
+type clock interface {
+	// getTime returns the current time in nanoseconds.
+	getTime() timestamp
+}
+
+type systemClock struct{}
+
+// getTime returns the current time in nanoseconds.
+func (c *systemClock) getTime() timestamp {
+	return timestamp(time.Now().UnixNano())
+}
+
+// NewHybridLogicalClock returns a new HLC from a previously initialized time.
+func NewHybridLogicalClock(lastTime timestamp) *hybridLogicalClock {
+	return &hybridLogicalClock{
+		highestTime: lastTime,
+		clock:       &systemClock{},
+	}
+}
+
+// Now returns the next time represented in nanoseconds. This can be the current timestamp, or if multiple occur in the same nanosecond, an increasing timestamp.
+func (c *hybridLogicalClock) Now() timestamp {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	physicalTime := c.clock.getTime()
+	if c.highestTime >= physicalTime {
+		c.counter++
+	} else {
+		c.counter = 0
+		c.highestTime = physicalTime
+	}
+	return c.highestTime + c.counter
+}

--- a/hlc_test.go
+++ b/hlc_test.go
@@ -1,0 +1,100 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rosmar
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHybridLogicalClockNow(t *testing.T) {
+	clock := hybridLogicalClock{clock: &systemClock{}}
+	timestamp1 := clock.Now()
+	timestamp2 := clock.Now()
+	require.Greater(t, timestamp2, timestamp1)
+}
+
+func generateTimestamps(wg *sync.WaitGroup, clock *hybridLogicalClock, n int, result chan []timestamp) {
+	defer wg.Done()
+	timestamps := make([]timestamp, n)
+	for i := 0; i < n; i++ {
+		timestamps[i] = clock.Now()
+	}
+	result <- timestamps
+}
+
+func TestHLCNowConcurrent(t *testing.T) {
+	clock := hybridLogicalClock{clock: &systemClock{}}
+	goroutines := 100
+	timestampCount := 100
+
+	wg := sync.WaitGroup{}
+	results := make(chan []timestamp)
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go generateTimestamps(&wg, &clock, timestampCount, results)
+	}
+
+	doneChan := make(chan struct{})
+	go func() {
+		wg.Wait()
+		doneChan <- struct{}{}
+	}()
+	allTimestamps := make([]timestamp, 0, goroutines*timestampCount)
+loop:
+	for {
+		select {
+		case timestamps := <-results:
+			allTimestamps = append(allTimestamps, timestamps...)
+		case <-doneChan:
+			break loop
+		}
+	}
+	uniqueTimestamps := make(map[timestamp]struct{})
+	for _, timestamp := range allTimestamps {
+		if _, ok := uniqueTimestamps[timestamp]; ok {
+			t.Errorf("Timestamp %d is not unique", timestamp)
+		}
+		uniqueTimestamps[timestamp] = struct{}{}
+	}
+}
+
+type fakeClock struct {
+	time timestamp
+}
+
+func (c *fakeClock) getTime() timestamp {
+	return c.time
+}
+
+func TestHLCReverseTime(t *testing.T) {
+	clock := &fakeClock{}
+	hlc := hybridLogicalClock{clock: clock}
+	require.Equal(t, timestamp(1), hlc.Now())
+	require.Equal(t, timestamp(2), hlc.Now())
+
+	// reverse time no counter
+	clock.time = timestamp(0)
+	require.Equal(t, timestamp(3), hlc.Now())
+
+	// reset time to normal
+	clock.time = timestamp(6)
+	require.Equal(t, timestamp(6), hlc.Now())
+
+	// reverse time again
+	clock.time = timestamp(1)
+	require.Equal(t, timestamp(7), hlc.Now())
+
+	// jump to a value we had previously
+	clock.time = timestamp(6)
+	require.Equal(t, int(timestamp(8)), int(hlc.Now()))
+	require.Equal(t, int(timestamp(9)), int(hlc.Now()))
+}

--- a/hlc_test.go
+++ b/hlc_test.go
@@ -68,10 +68,10 @@ loop:
 }
 
 type fakeClock struct {
-	time timestamp
+	time uint64
 }
 
-func (c *fakeClock) getTime() timestamp {
+func (c *fakeClock) getTime() uint64 {
 	return c.time
 }
 
@@ -82,19 +82,24 @@ func TestHLCReverseTime(t *testing.T) {
 	require.Equal(t, timestamp(2), hlc.Now())
 
 	// reverse time no counter
-	clock.time = timestamp(0)
+	clock.time = 0
 	require.Equal(t, timestamp(3), hlc.Now())
 
 	// reset time to normal
-	clock.time = timestamp(6)
-	require.Equal(t, timestamp(6), hlc.Now())
+	clock.time = 6
+	require.Equal(t, timestamp(0x60000), hlc.Now())
 
 	// reverse time again
-	clock.time = timestamp(1)
-	require.Equal(t, timestamp(7), hlc.Now())
+	clock.time = 1
+	require.Equal(t, timestamp(0x60001), hlc.Now())
 
 	// jump to a value we had previously
-	clock.time = timestamp(6)
-	require.Equal(t, int(timestamp(8)), int(hlc.Now()))
-	require.Equal(t, int(timestamp(9)), int(hlc.Now()))
+	clock.time = 6
+	require.Equal(t, timestamp(0x60002), hlc.Now())
+	require.Equal(t, timestamp(0x60003), hlc.Now())
+
+	// continue forward
+	clock.time = 7
+	require.Equal(t, timestamp(0x70000), hlc.Now())
+
 }

--- a/hlc_test.go
+++ b/hlc_test.go
@@ -78,28 +78,30 @@ func (c *fakeClock) getTime() uint64 {
 func TestHLCReverseTime(t *testing.T) {
 	clock := &fakeClock{}
 	hlc := hybridLogicalClock{clock: clock}
-	require.Equal(t, timestamp(1), hlc.Now())
-	require.Equal(t, timestamp(2), hlc.Now())
+	startTime := uint64(1000000) // 1 second
+	clock.time = startTime
+	require.Equal(t, timestamp(0xf0000), hlc.Now())
+	require.Equal(t, timestamp(0xf0001), hlc.Now())
 
 	// reverse time no counter
 	clock.time = 0
-	require.Equal(t, timestamp(3), hlc.Now())
+	require.Equal(t, timestamp(0xf0002), hlc.Now())
 
 	// reset time to normal
-	clock.time = 6
-	require.Equal(t, timestamp(0x60000), hlc.Now())
+	clock.time = startTime
+	require.Equal(t, timestamp(0xf0003), hlc.Now())
 
 	// reverse time again
 	clock.time = 1
-	require.Equal(t, timestamp(0x60001), hlc.Now())
+	require.Equal(t, timestamp(0xf0004), hlc.Now())
 
 	// jump to a value we had previously
-	clock.time = 6
-	require.Equal(t, timestamp(0x60002), hlc.Now())
-	require.Equal(t, timestamp(0x60003), hlc.Now())
+	clock.time = startTime * 2
+	require.Equal(t, timestamp(0x1e0000), hlc.Now())
+	require.Equal(t, timestamp(0x1e0001), hlc.Now())
 
 	// continue forward
-	clock.time = 7
-	require.Equal(t, timestamp(0x70000), hlc.Now())
+	clock.time *= 2
+	require.Equal(t, timestamp(0x3d0000), hlc.Now())
 
 }


### PR DESCRIPTION
- there is more locking than seems necessary here, but I don't think this will be in contention, especially becuase these are inside SQL transactions that are happening one at a time
- each bucket maintains it's own HLC, as it is stored inside the bucket db, and so needs to be re-initialized from the last possible clock that was serialized.