### PR TITLE
CBG-3703 create a basic bucket to bucket XDCR implementation [HAS DEPENDENCY]

### DIFF
--- a/bucket_test.go
+++ b/bucket_test.go
@@ -32,7 +32,7 @@ func init() {
 }
 
 // testCtx returns a context for testing
-func testCtx(t *testing.T) context.Context {
+func testCtx(_ *testing.T) context.Context {
 	return context.Background() // match sync gateway interfaces for logging
 }
 
@@ -45,9 +45,6 @@ func testBucketPath(t *testing.T) string {
 
 // makeTestBucketWithName creates a new persistent test bucket with a given name. If a bucket already exists, this function will fail. This uses testing.T.Cleanup to remove the bucket.
 func makeTestBucketWithName(t *testing.T, name string) *Bucket {
-	LoggingCallback = func(level LogLevel, fmt string, args ...any) {
-		t.Logf(logLevelNamesPrint[level]+fmt, args...)
-	}
 	bucket, err := OpenBucket(uriFromPath(testBucketPath(t)), name, CreateNew)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -194,8 +194,8 @@ func TestDefaultCollection(t *testing.T) {
 	coll := bucket.DefaultDataStore()
 	assert.NotNil(t, coll)
 	assert.Equal(t, bucketName+"._default._default", coll.GetName())
-	assert.Equal(t, "_default", coll.DataStoreName().ScopeName())
-	assert.Equal(t, "_default", coll.DataStoreName().CollectionName())
+	assert.Equal(t, "_default", coll.ScopeName())
+	assert.Equal(t, "_default", coll.CollectionName())
 }
 
 func TestCreateCollection(t *testing.T) {
@@ -211,8 +211,8 @@ func TestCreateCollection(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, coll)
 	assert.Equal(t, bucketName+"._default.foo", coll.GetName())
-	assert.Equal(t, "_default", coll.DataStoreName().ScopeName())
-	assert.Equal(t, "foo", coll.DataStoreName().CollectionName())
+	assert.Equal(t, "_default", coll.ScopeName())
+	assert.Equal(t, "foo", coll.CollectionName())
 	colls, err := bucket.ListDataStores()
 	assert.NoError(t, err)
 	assert.Equal(t, colls, []sgbucket.DataStoreName{defaultCollection, collName})

--- a/collection+xattrs.go
+++ b/collection+xattrs.go
@@ -39,7 +39,7 @@ func (c *Collection) GetXattrs(
 }
 
 // SetWithMeta updates a document fully with xattrs and body and allows specification of a specific CAS (newCas). This update will always happen as long as oldCas matches the value of existing document. This simulates the kv op setWithMeta.
-func (c *Collection) SetWithMeta(_ context.Context, key string, oldCas CAS, newCas CAS, exp uint32, xattrs []byte, body []byte, datatype sgbucket.FeedDataType) error {
+func (c *Collection) setWithMeta(key string, oldCas CAS, newCas CAS, exp uint32, xattrs []byte, body []byte, datatype sgbucket.FeedDataType) error {
 	isJSON := datatype&sgbucket.FeedDataTypeJSON != 0
 	isDeletion := false
 	return c.writeWithMeta(key, body, xattrs, oldCas, newCas, exp, isJSON, isDeletion)
@@ -80,8 +80,8 @@ func (c *Collection) writeWithMeta(key string, body []byte, xattrs []byte, oldCa
 	return nil
 }
 
-// DeleteWithMeta tombstones a document and sets a specific cas. This update will always happen as long as oldCas matches the value of existing document. This simulates the kv op deleteWithMeta.
-func (c *Collection) DeleteWithMeta(_ context.Context, key string, oldCas CAS, newCas CAS, exp uint32, xattrs []byte) error {
+// deleteWithMeta tombstones a document and sets a specific cas. This update will always happen as long as oldCas matches the value of existing document. This simulates the kv op deleteWithMeta.
+func (c *Collection) deleteWithMeta(key string, oldCas CAS, newCas CAS, exp uint32, xattrs []byte) error {
 	var body []byte
 	isJSON := false
 	isDeletion := true

--- a/collection.go
+++ b/collection.go
@@ -63,10 +63,17 @@ func (c *Collection) db() queryable {
 
 //////// Interface DataStore
 
+// GetName returns bucket.scope.collection name.
 func (c *Collection) GetName() string {
 	return c.bucket.GetName() + "." + c.DataStoreNameImpl.String()
 }
 
+// DataStoreName returns the scope and collection name.
+func (c *Collection) DataStoreName() sgbucket.DataStoreName {
+	return c.DataStoreNameImpl
+}
+
+// GetCollectionID returns a unique ID for a given collection, used to identify the collection in DCP feeds and other places.
 func (c *Collection) GetCollectionID() uint32 {
 	return uint32(c.id) - 1 // SG expects that the default collection has id 0, so subtract 1
 }

--- a/collection.go
+++ b/collection.go
@@ -68,9 +68,14 @@ func (c *Collection) GetName() string {
 	return c.bucket.GetName() + "." + c.DataStoreNameImpl.String()
 }
 
-// DataStoreName returns the scope and collection name.
-func (c *Collection) DataStoreName() sgbucket.DataStoreName {
-	return c.DataStoreNameImpl
+// ScopeName returns the scope name. _default for the default scope.
+func (c *Collection) ScopeName() string {
+	return c.DataStoreNameImpl.ScopeName()
+}
+
+// ScopeName returns the collection name. _default for the default collection
+func (c *Collection) CollectionName() string {
+	return c.DataStoreNameImpl.CollectionName()
 }
 
 // GetCollectionID returns a unique ID for a given collection, used to identify the collection in DCP feeds and other places.

--- a/feeds.go
+++ b/feeds.go
@@ -23,10 +23,6 @@ var activeFeedCount int32 // for tests
 
 //////// BUCKET API: (sgbucket.MutationFeedStore interface)
 
-func (bucket *Bucket) GetFeedType() sgbucket.FeedType {
-	return sgbucket.DcpFeedType
-}
-
 func (bucket *Bucket) StartDCPFeed(
 	ctx context.Context,
 	args sgbucket.FeedArguments,
@@ -82,13 +78,6 @@ func (bucket *Bucket) StartDCPFeed(
 	}()
 
 	return nil
-}
-
-func (wh *Bucket) StartTapFeed(
-	args sgbucket.FeedArguments,
-	dbStats *expvar.Map,
-) (sgbucket.MutationFeed, error) {
-	return nil, &ErrUnimplemented{"rosmar bucket doesn't support tap feed, use DCP"}
 }
 
 //////// COLLECTION API:
@@ -350,8 +339,3 @@ func (e *event) asFeedEvent(collectionID uint32) *sgbucket.FeedEvent {
 	}
 	return &feedEvent
 }
-
-var (
-	// Enforce interface conformance:
-	_ sgbucket.MutationFeedStore2 = &Bucket{}
-)

--- a/feeds_test.go
+++ b/feeds_test.go
@@ -190,7 +190,8 @@ func readExpectedEventsDEF(t *testing.T, events chan sgbucket.FeedEvent) {
 
 func TestCrossBucketEvents(t *testing.T) {
 	ensureNoLeakedFeeds(t)
-	bucket := makeTestBucket(t)
+	bucketName := strings.ToLower(t.Name())
+	bucket := makeTestBucketWithName(t, bucketName)
 	c := bucket.DefaultDataStore()
 
 	addToCollection(t, c, "able", 0, "A")
@@ -198,7 +199,7 @@ func TestCrossBucketEvents(t *testing.T) {
 	addToCollection(t, c, "charlie", 0, "C")
 
 	// Open a 2nd bucket on the same file, to receive events:
-	bucket2, err := OpenBucket(bucket.url, strings.ToLower(t.Name()), ReOpenExisting)
+	bucket2, err := OpenBucket(bucket.url, bucketName, ReOpenExisting)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		bucket2.Close(testCtx(t))
@@ -241,8 +242,8 @@ func TestCollectionMutations(t *testing.T) {
 	require.NoError(t, err)
 	numDocs := 50
 
-	collectionID_1 := collection1.(sgbucket.Collection).GetCollectionID()
-	collectionID_2 := collection2.(sgbucket.Collection).GetCollectionID()
+	collectionID_1 := collection1.GetCollectionID()
+	collectionID_2 := collection2.GetCollectionID()
 
 	// Add n docs to two collections
 	for i := 1; i <= numDocs; i++ {

--- a/go.mod
+++ b/go.mod
@@ -17,3 +17,5 @@ require (
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/couchbase/sg-bucket => ../sg-bucket

--- a/go.mod
+++ b/go.mod
@@ -17,5 +17,3 @@ require (
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/couchbase/sg-bucket => ../sg-bucket

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/couchbaselabs/rosmar
 go 1.19
 
 require (
-	github.com/couchbase/sg-bucket v0.0.0-20240402154301-12625d8851a8
+	github.com/couchbase/sg-bucket v0.0.0-20240405013818-2750c47d6936
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/stretchr/testify v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/couchbaselabs/rosmar
 go 1.19
 
 require (
-	github.com/couchbase/sg-bucket v0.0.0-20240326230241-0b197e169b27
+	github.com/couchbase/sg-bucket v0.0.0-20240327235911-eb1eb768174c
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/stretchr/testify v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/couchbaselabs/rosmar
 go 1.19
 
 require (
-	github.com/couchbase/sg-bucket v0.0.0-20240327235911-eb1eb768174c
+	github.com/couchbase/sg-bucket v0.0.0-20240401153043-4d86ea8a8a98
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/couchbase/sg-bucket v0.0.0-20240327235911-eb1eb768174c h1:IjO5PI0qJLJgiziRlbHVhTm7qGXyT/rY2rXHAJ53uNc=
-github.com/couchbase/sg-bucket v0.0.0-20240327235911-eb1eb768174c/go.mod h1:5me3TJLTPfR0s3aMJZcPoTu5FT8oelaINz5l7Q3cApE=
+github.com/couchbase/sg-bucket v0.0.0-20240401153043-4d86ea8a8a98 h1:rK0OBdmn+LeRCYKVrrub8jpzfRUkKZ3c+lAQHPItLRw=
+github.com/couchbase/sg-bucket v0.0.0-20240401153043-4d86ea8a8a98/go.mod h1:5me3TJLTPfR0s3aMJZcPoTu5FT8oelaINz5l7Q3cApE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/couchbase/sg-bucket v0.0.0-20240326230241-0b197e169b27 h1:FGNvJsAQk6JZzuVXvoLXcoSQzOnQxWkywzYJFQqzXEg=
-github.com/couchbase/sg-bucket v0.0.0-20240326230241-0b197e169b27/go.mod h1:5me3TJLTPfR0s3aMJZcPoTu5FT8oelaINz5l7Q3cApE=
+github.com/couchbase/sg-bucket v0.0.0-20240327235911-eb1eb768174c h1:IjO5PI0qJLJgiziRlbHVhTm7qGXyT/rY2rXHAJ53uNc=
+github.com/couchbase/sg-bucket v0.0.0-20240327235911-eb1eb768174c/go.mod h1:5me3TJLTPfR0s3aMJZcPoTu5FT8oelaINz5l7Q3cApE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/couchbase/sg-bucket v0.0.0-20240402154301-12625d8851a8 h1:kfWMYvUgSg2yIZJx+t63Ucl+zorvFqlYayXPkiXFtSE=
-github.com/couchbase/sg-bucket v0.0.0-20240402154301-12625d8851a8/go.mod h1:5me3TJLTPfR0s3aMJZcPoTu5FT8oelaINz5l7Q3cApE=
+github.com/couchbase/sg-bucket v0.0.0-20240405013818-2750c47d6936 h1:RQX9vRQ1orRgr9IyTcJemj0yjY0heUJfmAY70dPC+YQ=
+github.com/couchbase/sg-bucket v0.0.0-20240405013818-2750c47d6936/go.mod h1:5me3TJLTPfR0s3aMJZcPoTu5FT8oelaINz5l7Q3cApE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/xdcr.go
+++ b/xdcr.go
@@ -53,7 +53,6 @@ func NewXDCR(_ context.Context, fromBucket, toBucket *Bucket, opts sgbucket.XDCR
 func (r *XDCR) processEvent(event sgbucket.FeedEvent) bool {
 	docID := string(event.Key)
 	trace("Got event %s, opcode: %s", docID, event.Opcode)
-	fmt.Printf("Got event %s, opcode: %s\n", docID, event.Opcode)
 	col, ok := r.toBucketCollections[event.CollectionID]
 	if !ok {
 		logError("This violates the assumption that all collections are mapped to a target collection. This should not happen. Found event=%+v", event)
@@ -65,7 +64,6 @@ func (r *XDCR) processEvent(event sgbucket.FeedEvent) bool {
 	case sgbucket.FeedOpDeletion, sgbucket.FeedOpMutation:
 		// Filter out events if we have a non XDCR filter
 		if r.filterFunc != nil && !r.filterFunc(&event) {
-			fmt.Printf("Filtering %s\n", docID)
 			trace("Filtering doc %s", docID)
 			r.docsFiltered.Add(1)
 			return true

--- a/xdcr.go
+++ b/xdcr.go
@@ -1,0 +1,243 @@
+// Copyright 2024-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rosmar
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+)
+
+// XDCR implements a XDCR bucket to bucket setup within rosmar.
+type XDCR struct {
+	terminator              chan bool
+	fromBucketCollectionIDs map[uint32]sgbucket.DataStoreName
+	fromBucket              *Bucket
+	toBucket                *Bucket
+	replicationID           string
+	docsWritten             atomic.Uint64
+	docsFiltered            atomic.Uint64
+	errorCount              atomic.Uint64
+}
+
+// NewXDCR creates an instance of XDCR backed by rosmar. This is not started until Start is called.
+func NewXDCR(_ context.Context, fromBucket, toBucket *Bucket, opts sgbucket.XDCROptions) (*XDCR, error) {
+
+	return &XDCR{
+		fromBucket:              fromBucket,
+		toBucket:                toBucket,
+		replicationID:           fmt.Sprintf("%s-%s", fromBucket.GetName(), toBucket.GetName()),
+		fromBucketCollectionIDs: map[uint32]sgbucket.DataStoreName{},
+		terminator:              make(chan bool),
+	}, nil
+
+}
+
+// getFromBucketCollectionName returns the collection name for a given collection ID in the from bucket.
+func (r *XDCR) getFromBucketCollectionName(collectionID uint32) (sgbucket.DataStoreName, error) {
+	dsName, ok := r.fromBucketCollectionIDs[collectionID]
+	if ok {
+		return dsName, nil
+	}
+
+	dataStores, err := r.fromBucket.ListDataStores()
+
+	if err != nil {
+		return nil, fmt.Errorf("Could not list data stores: %w", err)
+
+	}
+
+	for _, dsName := range dataStores {
+		dataStore, err := r.fromBucket.NamedDataStore(dsName)
+		if err != nil {
+			return nil, fmt.Errorf("Could not get data store %s: %w", dsName, err)
+		}
+
+		if dataStore.GetCollectionID() == collectionID {
+			name := dataStore.DataStoreName()
+			r.fromBucketCollectionIDs[collectionID] = name
+			return name, nil
+
+		}
+	}
+	return nil, fmt.Errorf("Could not find collection with ID %d", collectionID)
+}
+
+// Start starts the replication.
+func (r *XDCR) Start(ctx context.Context) error {
+	args := sgbucket.FeedArguments{
+		ID:         "xdcr-" + r.replicationID,
+		Backfill:   sgbucket.FeedNoBackfill,
+		Terminator: r.terminator,
+	}
+
+	callback := func(event sgbucket.FeedEvent) bool {
+		docID := string(event.Key)
+		trace("Got event %s, opcode: %s", docID, event.Opcode)
+		dsName, err := r.getFromBucketCollectionName(event.CollectionID)
+		if err != nil {
+			warn("Could not find collection with ID %d for docID %s: %s", event.CollectionID, docID, err)
+			r.errorCount.Add(1)
+			return false
+
+		}
+
+		switch event.Opcode {
+		case sgbucket.FeedOpDeletion, sgbucket.FeedOpMutation:
+			if strings.HasPrefix(docID, sgbucket.SyncDocPrefix) && !strings.HasPrefix(docID, sgbucket.Att2Prefix) {
+				trace("Filtering doc %s", docID)
+				r.docsFiltered.Add(1)
+				return true
+
+			}
+
+			toDataStore, err := r.toBucket.NamedDataStore(dsName)
+			if err != nil {
+				warn("Replicating doc %s, could not find matching datastore for %s in target bucket", event.Key, dsName)
+				r.errorCount.Add(1)
+				return false
+			}
+
+			originalCas, err := toDataStore.Get(docID, nil)
+			if err != nil && !toDataStore.IsError(err, sgbucket.KeyNotFoundError) {
+				warn("Skipping replicating doc %s, could not perform a kv op get doc in toBucket: %s", event.Key, err)
+				r.errorCount.Add(1)
+				return false
+			}
+
+			/* full LWW conflict resolution is not implemented in rosmar yet
+
+			CBS algorithm is:
+
+			if (command.CAS > document.CAS)
+			  command succeeds
+			else if (command.CAS == document.CAS)
+			  // Check the RevSeqno
+			  if (command.RevSeqno > document.RevSeqno)
+			    command succeeds
+			  else if (command.RevSeqno == document.RevSeqno)
+			    // Check the expiry time
+			    if (command.Expiry > document.Expiry)
+			      command succeeds
+			    else if (command.Expiry == document.Expiry)
+			      // Finally check flags
+			      if (command.Flags < document.Flags)
+			        command succeeds
+
+
+			command fails
+
+			In the current state of rosmar:
+
+			1. all CAS values are unique.
+			2. RevSeqno is not implemented
+			3. Expiry is implemented and could be compared except all CAS values are unique.
+			4. Flags are not implemented
+
+			*/
+
+			if event.Cas <= originalCas {
+				trace("Skipping replicating doc %s, cas %d <= %d", docID, event.Cas, originalCas)
+				return true
+			}
+
+			toCollection, ok := toDataStore.(*Collection)
+			if !ok {
+				warn("Datastore is not of type Collection, is of type %T", toDataStore)
+				r.errorCount.Add(1)
+			}
+
+			err = writeDoc(ctx, toCollection, originalCas, event)
+			if err != nil {
+				warn("Replicating doc %s, could not write doc: %s", event.Key, err)
+				r.errorCount.Add(1)
+				return false
+
+			}
+			r.docsWritten.Add(1)
+		}
+
+		return true
+
+	}
+	return r.fromBucket.StartDCPFeed(ctx, args, callback, nil)
+}
+
+// Stop terminates the replication.
+func (r *XDCR) Stop(_ context.Context) error {
+	close(r.terminator)
+	r.terminator = nil
+	return nil
+}
+
+// writeDoc writes a document to the target datastore. This will not return an error on a CAS mismatch, but will return error on other types of write.
+func writeDoc(ctx context.Context, collection *Collection, originalCas uint64, event sgbucket.FeedEvent) error {
+	if event.Opcode == sgbucket.FeedOpDeletion {
+		_, err := collection.Remove(string(event.Key), originalCas)
+		if !errors.Is(err, sgbucket.CasMismatchErr{}) {
+			return err
+		}
+		return nil
+	}
+
+	var xattrs []byte
+	var body []byte
+	if event.DataType&sgbucket.FeedDataTypeXattr != 0 {
+		var err error
+		var dcpXattrs []sgbucket.Xattr
+		body, dcpXattrs, err = sgbucket.DecodeValueWithXattrs(event.Value)
+		if err != nil {
+			return err
+		}
+
+		xattrs, err = xattrToBytes(dcpXattrs)
+		if err != nil {
+			return err
+		}
+
+	} else {
+
+		body = event.Value
+
+	}
+
+	err := collection.SetWithMeta(ctx, string(event.Key), originalCas, event.Cas, event.Expiry, xattrs, body, event.DataType)
+
+	if !collection.IsError(err, sgbucket.KeyNotFoundError) {
+		return err
+	}
+
+	return nil
+
+}
+
+// Stats returns the stats of the XDCR replication.
+
+func (r *XDCR) Stats(context.Context) (*sgbucket.XDCRStats, error) {
+
+	return &sgbucket.XDCRStats{
+		DocsWritten:  r.docsWritten.Load(),
+		DocsFiltered: r.docsFiltered.Load(),
+		ErrorCount:   r.errorCount.Load(),
+	}, nil
+}
+
+// xattrToBytes converts a slice of Xattrs to a byte slice of marshalled json.
+func xattrToBytes(xattrs []sgbucket.Xattr) ([]byte, error) {
+	xattrMap := make(map[string]json.RawMessage)
+	for _, xattr := range xattrs {
+		xattrMap[xattr.Name] = xattr.Value
+	}
+	return json.Marshal(xattrMap)
+}

--- a/xdcr.go
+++ b/xdcr.go
@@ -33,7 +33,9 @@ type XDCR struct {
 
 // NewXDCR creates an instance of XDCR backed by rosmar. This is not started until Start is called.
 func NewXDCR(_ context.Context, fromBucket, toBucket *Bucket, opts sgbucket.XDCROptions) (*XDCR, error) {
-
+	if opts.Mobile != sgbucket.XDCRMobileOn {
+		return nil, errors.New("Only sgbucket.XDCRMobileOn is supported in rosmar")
+	}
 	return &XDCR{
 		fromBucket:              fromBucket,
 		toBucket:                toBucket,

--- a/xdcr.go
+++ b/xdcr.go
@@ -129,7 +129,7 @@ func (r *XDCR) processEvent(event sgbucket.FeedEvent) bool {
 
 }
 
-// Start starts the replication.
+// Start starts the replication for all existing replications. Errors if there aren't corresponding named collections on each bucket.
 func (r *XDCR) Start(ctx context.Context) error {
 	// set up replication to target all existing collections, and map to other collections
 	scopes := make(map[string][]string)

--- a/xdcr_test.go
+++ b/xdcr_test.go
@@ -1,0 +1,141 @@
+package rosmar
+
+// Copyright 2024-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestXDCR(t *testing.T) {
+	ctx := testCtx(t)
+	fromBucket := makeTestBucket(t)
+	toBucket := makeTestBucket(t)
+	defer fromBucket.Close(ctx)
+	defer toBucket.Close(ctx)
+
+	xdcr, err := NewXDCR(ctx, fromBucket, toBucket, sgbucket.XDCROptions{})
+	require.NoError(t, err)
+	err = xdcr.Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, xdcr.Stop(ctx))
+	}()
+	const (
+		syncDoc           = "_sync:doc1doc2"
+		attachmentDoc     = "_sync:att2:foo"
+		attachmentDocBody = `1ABINARYBLOB`
+		normalDoc         = "doc2"
+		normalDocBody     = `{"key":"value"}`
+		exp               = 0
+	)
+	_, err = fromBucket.DefaultDataStore().AddRaw(syncDoc, exp, []byte(`{"foo", "bar"}`))
+	require.NoError(t, err)
+
+	attachmentDocCas, err := fromBucket.DefaultDataStore().WriteCas(attachmentDoc, exp, 0, []byte(attachmentDocBody), sgbucket.Raw)
+	require.NoError(t, err)
+
+	normalDocCas, err := fromBucket.DefaultDataStore().WriteCas(normalDoc, exp, 0, []byte(normalDocBody), 0)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		val, cas, err := toBucket.DefaultDataStore().GetRaw(normalDoc)
+		assert.NoError(c, err)
+		assert.Equal(c, normalDocCas, cas)
+		assert.JSONEq(c, normalDocBody, string(val))
+	}, time.Second*5, time.Millisecond*100)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		val, cas, err := toBucket.DefaultDataStore().GetRaw(attachmentDoc)
+		assert.NoError(c, err)
+		assert.Equal(c, attachmentDocCas, cas)
+		assert.Equal(c, []byte(attachmentDocBody), val)
+	}, time.Second*5, time.Millisecond*100)
+
+	_, err = toBucket.DefaultDataStore().Get(syncDoc, nil)
+	assert.True(t, toBucket.IsError(err, sgbucket.KeyNotFoundError))
+
+	require.NoError(t, fromBucket.DefaultDataStore().Delete(normalDoc))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		var value string
+		_, err = toBucket.DefaultDataStore().Get(normalDoc, &value)
+		assert.Error(t, err)
+		assert.True(t, toBucket.IsError(err, sgbucket.KeyNotFoundError))
+	}, time.Second*5, time.Millisecond*100)
+
+	// stats are not updated in real time, so we need to wait a bit
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		stats, err := xdcr.Stats(ctx)
+		assert.NoError(t, err)
+		assert.Equal(c, uint64(1), stats.DocsFiltered)
+		assert.Equal(c, uint64(3), stats.DocsWritten)
+	}, time.Second*5, time.Millisecond*100)
+
+	stats, err := xdcr.Stats(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), stats.ErrorCount)
+}
+
+func TestXattrMigration(t *testing.T) {
+	ctx := testCtx(t)
+	fromBucket := makeTestBucket(t)
+	toBucket := makeTestBucket(t)
+	defer fromBucket.Close(ctx)
+	defer toBucket.Close(ctx)
+
+	xdcr, err := NewXDCR(ctx, fromBucket, toBucket, sgbucket.XDCROptions{})
+	require.NoError(t, err)
+	err = xdcr.Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, xdcr.Stop(ctx))
+	}()
+
+	const (
+		docID           = "doc1"
+		systemXattrName = "_system"
+		userXattrName   = "user"
+		body            = `{"foo": "bar"}`
+		systemXattrVal  = `{"bar": "baz"}`
+		userXattrVal    = `{"baz": "baz"}`
+		isDelete        = false
+		deleteBody      = false
+	)
+
+	startingCas, err := fromBucket.DefaultDataStore().WriteWithXattrs(ctx, docID, 0, 0, []byte(body), map[string][]byte{systemXattrName: []byte(systemXattrVal)}, nil)
+	require.NoError(t, err)
+	require.Greater(t, startingCas, uint64(0))
+
+	startingCas, err = fromBucket.DefaultDataStore().SetXattrs(ctx, docID, map[string][]byte{userXattrName: []byte(userXattrVal)})
+	require.NoError(t, err)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		toVal, xattrs, cas, err := toBucket.DefaultDataStore().GetWithXattrs(ctx, docID, []string{systemXattrName, userXattrName})
+		assert.NoError(c, err)
+		assert.Equal(c, startingCas, cas)
+		assert.JSONEq(c, body, string(toVal))
+		assert.JSONEq(c, systemXattrVal, string(xattrs[systemXattrName]))
+		assert.JSONEq(c, userXattrVal, string(xattrs[userXattrName]))
+
+	}, time.Second*5, time.Millisecond*100)
+	stats, err := xdcr.Stats(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), stats.ErrorCount)
+}
+
+func mustUnmarshalJSON(t *testing.T, val string) map[string]string {
+	var v map[string]string
+	err := json.Unmarshal([]byte(val), &v)
+	require.NoError(t, err)
+	return v
+}

--- a/xdcr_test.go
+++ b/xdcr_test.go
@@ -24,7 +24,7 @@ func TestXDCR(t *testing.T) {
 	defer fromBucket.Close(ctx)
 	defer toBucket.Close(ctx)
 
-	xdcr, err := NewXDCR(ctx, fromBucket, toBucket, sgbucket.XDCROptions{})
+	xdcr, err := NewXDCR(ctx, fromBucket, toBucket, sgbucket.XDCROptions{Mobile: sgbucket.XDCRMobileOn})
 	require.NoError(t, err)
 	err = xdcr.Start(ctx)
 	require.NoError(t, err)
@@ -93,7 +93,7 @@ func TestXattrMigration(t *testing.T) {
 	defer fromBucket.Close(ctx)
 	defer toBucket.Close(ctx)
 
-	xdcr, err := NewXDCR(ctx, fromBucket, toBucket, sgbucket.XDCROptions{})
+	xdcr, err := NewXDCR(ctx, fromBucket, toBucket, sgbucket.XDCROptions{Mobile: sgbucket.XDCRMobileOn})
 	require.NoError(t, err)
 	err = xdcr.Start(ctx)
 	require.NoError(t, err)

--- a/xdcr_test.go
+++ b/xdcr_test.go
@@ -9,7 +9,6 @@ package rosmar
 // the file licenses/APL2.txt.
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 
@@ -109,8 +108,6 @@ func TestXattrMigration(t *testing.T) {
 		body            = `{"foo": "bar"}`
 		systemXattrVal  = `{"bar": "baz"}`
 		userXattrVal    = `{"baz": "baz"}`
-		isDelete        = false
-		deleteBody      = false
 	)
 
 	startingCas, err := fromBucket.DefaultDataStore().WriteWithXattrs(ctx, docID, 0, 0, []byte(body), map[string][]byte{systemXattrName: []byte(systemXattrVal)}, nil)
@@ -131,11 +128,4 @@ func TestXattrMigration(t *testing.T) {
 	stats, err := xdcr.Stats(ctx)
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), stats.ErrorCount)
-}
-
-func mustUnmarshalJSON(t *testing.T, val string) map[string]string {
-	var v map[string]string
-	err := json.Unmarshal([]byte(val), &v)
-	require.NoError(t, err)
-	return v
 }


### PR DESCRIPTION
- uses new common elements from sg-bucket
- absorbs DataStoreName and GetCollectionID into DataStore to avoid duplication
- The implementation only copies documents with xattrs, and excludes specially named documents. It does not implement 
_vv, _mou, or _sync handling.
- test is duplicated in sync_gateway xdcr package with the code matching the common interface

https://github.com/couchbase/sg-bucket/pull/117

Includes https://github.com/couchbaselabs/rosmar/pull/30 which can be merged independently