### PR TITLE
match Couchbase Server DCP behavior

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -135,7 +135,7 @@ func (c *Collection) GetAndTouchRaw(key string, exp Exp) (val []byte, cas CAS, e
 
 func (c *Collection) AddRaw(key string, exp Exp, val []byte) (added bool, err error) {
 	traceEnter("AddRaw", "%q, %d, ...", key, exp)
-	added, err = c.add(key, exp, val, looksLikeJSON(val))
+	added, err = c.add(key, exp, val, json.Valid(val))
 	traceExit("AddRaw", err, "%v", added)
 	return
 }
@@ -176,7 +176,7 @@ func (c *Collection) add(key string, exp Exp, val []byte, isJSON bool) (added bo
 
 func (c *Collection) SetRaw(key string, exp Exp, opts *sgbucket.UpsertOptions, val []byte) (err error) {
 	traceEnter("SetRaw", "%q, %d, ...", key, exp)
-	err = c.set(key, exp, opts, val, false)
+	err = c.set(key, exp, opts, val, json.Valid(val))
 	traceExit("SetRaw", err, "ok")
 	return
 }

--- a/utils.go
+++ b/utils.go
@@ -88,11 +88,6 @@ func ifelse[T any](cond bool, ifTrue T, ifFalse T) T {
 	}
 }
 
-// Quick and dirty heuristic to check whether a byte-string is a JSON object.
-func looksLikeJSON(data []byte) bool {
-	return len(data) >= 2 && data[0] == '{' && data[len(data)-1] == '}'
-}
-
 //////// ENCODING / DECODING VALUES:
 
 //////// CRC32:


### PR DESCRIPTION
Couchbase Server will detect JSON on the server side, so AddRaw and SetRaw will do a full check for JSON.

While Sync Gateway only recognizes binary or JSON objects, Couchbase Server will declare valid json primitives as JSON.