### PR TITLE
CBG-4252 Use shared clock for all buckets

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -42,7 +42,6 @@ type Bucket struct {
 	serial          uint32         // Serial number for logging
 	inMemory        bool           // True if it's an in-memory database
 	closed          bool           // represents state when it is closed
-	hlc             *hybridLogicalClock
 }
 
 type collectionsMap = map[sgbucket.DataStoreNameImpl]*Collection
@@ -196,7 +195,7 @@ func OpenBucket(urlStr string, bucketName string, mode OpenMode) (b *Bucket, err
 		return nil, err
 	}
 
-	bucket.hlc = NewHybridLogicalClock(bucket.getLastTimestamp())
+	hlc.updateLatestTime(bucket.getLastTimestamp())
 
 	exists, bucketCopy := registerBucket(bucket)
 	// someone else beat registered the bucket in the registry, that's OK we'll close ours
@@ -388,7 +387,6 @@ func (b *Bucket) copy() *Bucket {
 		expManager:      b.expManager,
 		serial:          b.serial,
 		inMemory:        b.inMemory,
-		hlc:             b.hlc,
 	}
 	return r
 }

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -41,10 +41,14 @@ func testBucketPath(t *testing.T) string {
 }
 
 func makeTestBucket(t *testing.T) *Bucket {
+	return makeTestBucketWithName(t, strings.ToLower(t.Name()))
+}
+
+func makeTestBucketWithName(t *testing.T, name string) *Bucket {
 	LoggingCallback = func(level LogLevel, fmt string, args ...any) {
 		t.Logf(logLevelNamesPrint[level]+fmt, args...)
 	}
-	bucket, err := OpenBucket(uriFromPath(testBucketPath(t)), strings.ToLower(t.Name()), CreateNew)
+	bucket, err := OpenBucket(uriFromPath(testBucketPath(t)), name, CreateNew)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, bucket.CloseAndDelete(testCtx(t)))

--- a/collection.go
+++ b/collection.go
@@ -591,7 +591,7 @@ func (c *Collection) setLastCas(txn *sql.Tx, cas CAS) (err error) {
 func (c *Collection) withNewCas(fn func(txn *sql.Tx, newCas CAS) (*event, error)) error {
 	var e *event
 	err := c.bucket.inTransaction(func(txn *sql.Tx) error {
-		newCas := uint64(c.bucket.hlc.Now())
+		newCas := uint64(hlc.Now())
 		var err error
 		e, err = fn(txn, newCas)
 		if err != nil {

--- a/hlc.go
+++ b/hlc.go
@@ -13,6 +13,12 @@ import (
 	"time"
 )
 
+var hlc *hybridLogicalClock
+
+func init() {
+	hlc = NewHybridLogicalClock(0)
+}
+
 type timestamp uint64
 
 // hybridLogicalClock is a hybrid logical clock implementation for rosmar that produces timestamps that will always be increasing regardless of clock changes.
@@ -40,6 +46,14 @@ func NewHybridLogicalClock(lastTime timestamp) *hybridLogicalClock {
 	return &hybridLogicalClock{
 		highestTime: uint64(lastTime),
 		clock:       &systemClock{},
+	}
+}
+
+func (c *hybridLogicalClock) updateLatestTime(lastTime timestamp) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if uint64(lastTime) > c.highestTime {
+		c.highestTime = uint64(lastTime)
 	}
 }
 


### PR DESCRIPTION
This is not required for the implementation like couchbase server spec, but this allows for easier testing of XDCR bucket to bucket since it guarantees that a document of the same name will have a unique cas regardless of the bucket it is written to.

This basically allows to https://github.com/couchbase/sync_gateway/pull/7118 to work robustly, especially for windows where the clock is of multi millisecond precision.