### PR TITLE
CBG-4419 Return cas from GetWithXattrs when no doc, xattrs found

### DIFF
--- a/collection+xattrs.go
+++ b/collection+xattrs.go
@@ -477,12 +477,12 @@ func checkCasXattr(existingCas, expectedCas *CAS, opts writeXattrOptions) error 
 
 // Swiss Army knife method for modifying a document xattr, with or without changing the body.
 func (c *Collection) writeWithXattrs(
-	key string,                           // doc key
-	val *payload,                         // if non-nil, updates doc body; a nil payload means delete
-	xattrsPayload map[string]payload,     // xattr key/val; a nil payload deletes the xattr
-	ifCas *CAS,                           // if non-nil, must match current CAS; 0 for insert
-	exp *Exp,                             // if non-nil, sets expiration to this value
-	opts writeXattrOptions,               // option flags
+	key string, // doc key
+	val *payload, // if non-nil, updates doc body; a nil payload means delete
+	xattrsPayload map[string]payload, // xattr key/val; a nil payload deletes the xattr
+	ifCas *CAS, // if non-nil, must match current CAS; 0 for insert
+	exp *Exp, // if non-nil, sets expiration to this value
+	opts writeXattrOptions, // option flags
 	mutateOpts *sgbucket.MutateInOptions, // expiry and macro expansion options
 ) (casOut CAS, err error) {
 	parsedXattrs := make(map[string]any, len(xattrsPayload))


### PR DESCRIPTION
In the case where a tombstone exists but doesn't have any of the requested xattrs, GetWithXattrs should return the document cas for use for subsequent writes.