### PR TITLE
Update github workflows to match sync gateway

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,11 @@ jobs:
     name: addlicense
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.1
+          go-version: 1.23.4
       - run: go install github.com/google/addlicense@latest
-      - uses: actions/checkout@v3
       - run: addlicense -check -f licenses/addlicense.tmpl .
 
   test:
@@ -41,10 +40,10 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.1
+          go-version: 1.23.4
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
@@ -52,7 +51,7 @@ jobs:
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.6.0
+        uses: guyarb/golang-test-annotations@v0.8.0
         with:
           test-results: test.json
 
@@ -60,29 +59,28 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.3
+          go-version: 1.23.4
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.55.0
+          version: v1.63.4
 
   test-race:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.1
-      - uses: actions/checkout@v3
+          go-version: 1.23.4
       - name: Run Tests
         run: go test -race -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.6.0
+        uses: guyarb/golang-test-annotations@v0.8.0
         with:
           test-results: test.json

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,17 +43,13 @@ linters:
     - gocyclo # Computes and checks the cyclomatic complexity of functions
     - godot # Check if comments end in a period
     - godox # Tool for detection of FIXME, TODO and other comment keywords
-    - goerr113 # Golang linter to check the errors handling expressions
     - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
-    - gomnd # An analyzer to detect magic numbers.
     - gomodguard # Allow and block list linter for direct Go module dependencies.
-    - interfacer # Linter that suggests narrower interface types
     - lll # Reports long lines
     - misspell # Finds commonly misspelled English words in comments
     - nestif # Reports deeply nested if statements
     - nolintlint # Reports ill-formed or insufficient nolint directives
     - rowserrcheck # checks whether Err of rows is checked successfully
-    - scopelint # Scopelint checks for unpinned variables in go programs
     - stylecheck # Stylecheck is a replacement for golint
     - testpackage # linter that makes you use a separate _test package
     - unused # (megacheck) Checks Go code for unused constants, variables, functions and types
@@ -61,7 +57,6 @@ linters:
     - wsl # Whitespace Linter - Forces you to use empty lines!
     # Once fixed, should enable
     - bodyclose # checks whether HTTP response body is closed successfully
-    - deadcode # Finds unused code
     - dupl # Tool for code clone detection
     - goconst # Finds repeated strings that could be replaced by a constant
     - gocritic # The most opinionated Go source code linter
@@ -73,10 +68,8 @@ linters:
     - prealloc # Finds slice declarations that could potentially be preallocated
     - revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
     - staticcheck # (megacheck) Staticcheck is a go vet on steroids, applying a ton of static analysis checks
-    - structcheck # Finds unused struct fields
     - unconvert # Remove unnecessary type conversions
     - unparam # Reports unused function parameters
-    - varcheck # Finds unused global variables and constants
 
 # Don't enable fieldalignment, changing the field alignment requires checking to see if anyone uses constructors
 # without names. If there is a memory issue on a specific field, that is best found with a heap profile.

--- a/collection_test.go
+++ b/collection_test.go
@@ -877,7 +877,7 @@ func TestDeleteWithMetaXattr(t *testing.T) {
 	require.ErrorAs(t, err, &sgbucket.CasMismatchErr{})
 
 	// tombstone with a good cas
-	err = col.DeleteWithMeta(ctx, docID, startingCas, specifiedCas, 0, []byte(fmt.Sprintf(fmt.Sprintf(`{"%s": "%s"}`, systemXattr, systemXattrVal))))
+	err = col.DeleteWithMeta(ctx, docID, startingCas, specifiedCas, 0, []byte(fmt.Sprintf(`{"%s": "%s"}`, systemXattr, systemXattrVal)))
 	require.NoError(t, err)
 
 	_, err = col.Get(docID, nil)


### PR DESCRIPTION
fix golangci-lint config file to remove deprecated linters, fix lint issue

prevents warning spew when running golangci-lint locally