### PR TITLE
Implement KV range scan for Rosmar

### DIFF
--- a/bucket_api.go
+++ b/bucket_api.go
@@ -110,6 +110,8 @@ func (bucket *Bucket) IsSupported(feature sgbucket.BucketStoreFeature) bool {
 		return true
 	case sgbucket.BucketStoreFeatureSystemCollections:
 		return true
+	case sgbucket.BucketStoreFeatureRangeScan:
+		return true
 	default:
 		return false
 	}

--- a/collection+rangescan.go
+++ b/collection+rangescan.go
@@ -1,0 +1,135 @@
+// Copyright 2025-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rosmar
+
+import (
+	"database/sql"
+	"fmt"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+)
+
+// Ensure Collection implements RangeScanStore.
+var _ sgbucket.RangeScanStore = &Collection{}
+
+func (c *Collection) Scan(scanType sgbucket.ScanType, opts sgbucket.ScanOptions) (sgbucket.ScanResultIterator, error) {
+	rs, ok := scanType.(sgbucket.RangeScan)
+	if !ok {
+		return nil, fmt.Errorf("unsupported scan type: %T", scanType)
+	}
+	return c.rangeScan(rs, opts)
+}
+
+func (c *Collection) rangeScan(rs sgbucket.RangeScan, opts sgbucket.ScanOptions) (sgbucket.ScanResultIterator, error) {
+	var query string
+	var args []any
+
+	if opts.IDsOnly {
+		query = "SELECT key, cas FROM documents WHERE collection=? AND value IS NOT NULL"
+	} else {
+		query = "SELECT key, value, cas FROM documents WHERE collection=? AND value IS NOT NULL"
+	}
+	args = append(args, c.id)
+
+	if rs.From != nil {
+		if rs.From.Exclusive {
+			query += " AND key > ?"
+		} else {
+			query += " AND key >= ?"
+		}
+		args = append(args, rs.From.Term)
+	}
+	if rs.To != nil {
+		if rs.To.Exclusive {
+			query += " AND key < ?"
+		} else {
+			query += " AND key <= ?"
+		}
+		args = append(args, rs.To.Term)
+	}
+	query += " ORDER BY key"
+
+	return c.execScan(query, args, opts.IDsOnly)
+}
+
+func (c *Collection) execScan(query string, args []any, idsOnly bool) (sgbucket.ScanResultIterator, error) {
+	rows, err := c.db().Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("range scan query failed: %w", err)
+	}
+
+	iter := &scanIterator{rows: rows, idsOnly: idsOnly}
+	if c.bucket.inMemory {
+		// An in-memory database has only a single connection, so leaving sql.Rows open
+		// can cause deadlock. Read all rows eagerly and close immediately.
+		return preRecordScan(iter), nil
+	}
+	return iter, nil
+}
+
+// scanIterator wraps sql.Rows for streaming scan results.
+type scanIterator struct {
+	rows    *sql.Rows
+	idsOnly bool
+}
+
+func (it *scanIterator) Next() *sgbucket.ScanResultItem {
+	if !it.rows.Next() {
+		return nil
+	}
+	item := &sgbucket.ScanResultItem{IDOnly: it.idsOnly}
+	var err error
+	if it.idsOnly {
+		err = it.rows.Scan(&item.ID, &item.Cas)
+	} else {
+		err = it.rows.Scan(&item.ID, &item.Body, &item.Cas)
+	}
+	if err != nil {
+		return nil
+	}
+	return item
+}
+
+func (it *scanIterator) Close() error {
+	return it.rows.Close()
+}
+
+// preRecordedScanIterator holds all scan results in memory.
+type preRecordedScanIterator struct {
+	items []*sgbucket.ScanResultItem
+	err   error
+}
+
+func preRecordScan(iter *scanIterator) *preRecordedScanIterator {
+	var items []*sgbucket.ScanResultItem
+	for {
+		item := iter.Next()
+		if item == nil {
+			break
+		}
+		items = append(items, item)
+	}
+	return &preRecordedScanIterator{
+		items: items,
+		err:   iter.Close(),
+	}
+}
+
+func (it *preRecordedScanIterator) Next() *sgbucket.ScanResultItem {
+	if len(it.items) == 0 || it.err != nil {
+		return nil
+	}
+	item := it.items[0]
+	it.items = it.items[1:]
+	return item
+}
+
+func (it *preRecordedScanIterator) Close() error {
+	return it.err
+}

--- a/collection+rangescan.go
+++ b/collection+rangescan.go
@@ -53,7 +53,10 @@ func (c *Collection) rangeScan(ctx context.Context, rs sgbucket.RangeScan, opts 
 		}
 		args = append(args, rs.To.Term)
 	}
-	query += " ORDER BY key"
+	// No ORDER BY: gocb's Scan interleaves per-vBucket result streams without a
+	// global sort, so the sgbucket interface promises no global ordering. Not
+	// sorting here forces consumers to be order-agnostic and keeps rosmar's
+	// behavior aligned with CBS.
 
 	rows, err := c.db().Query(query, args...)
 	if err != nil {

--- a/collection+rangescan.go
+++ b/collection+rangescan.go
@@ -9,31 +9,31 @@
 package rosmar
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 )
 
-// Ensure Collection implements RangeScanStore.
 var _ sgbucket.RangeScanStore = &Collection{}
 
-func (c *Collection) Scan(scanType sgbucket.ScanType, opts sgbucket.ScanOptions) (sgbucket.ScanResultIterator, error) {
+func (c *Collection) Scan(ctx context.Context, scanType sgbucket.ScanType, opts sgbucket.ScanOptions) (sgbucket.ScanResultIterator, error) {
 	rs, ok := scanType.(sgbucket.RangeScan)
 	if !ok {
 		return nil, fmt.Errorf("unsupported scan type: %T", scanType)
 	}
-	return c.rangeScan(rs, opts)
+	return c.rangeScan(ctx, rs, opts)
 }
 
-func (c *Collection) rangeScan(rs sgbucket.RangeScan, opts sgbucket.ScanOptions) (sgbucket.ScanResultIterator, error) {
+func (c *Collection) rangeScan(ctx context.Context, rs sgbucket.RangeScan, opts sgbucket.ScanOptions) (sgbucket.ScanResultIterator, error) {
 	var query string
 	var args []any
 
 	if opts.IDsOnly {
-		query = "SELECT key, cas FROM documents WHERE collection=? AND value IS NOT NULL"
+		query = "SELECT key, cas FROM documents WHERE collection=? AND tombstone=0"
 	} else {
-		query = "SELECT key, value, cas FROM documents WHERE collection=? AND value IS NOT NULL"
+		query = "SELECT key, value, cas FROM documents WHERE collection=? AND tombstone=0"
 	}
 	args = append(args, c.id)
 
@@ -55,20 +55,16 @@ func (c *Collection) rangeScan(rs sgbucket.RangeScan, opts sgbucket.ScanOptions)
 	}
 	query += " ORDER BY key"
 
-	return c.execScan(query, args, opts.IDsOnly)
-}
-
-func (c *Collection) execScan(query string, args []any, idsOnly bool) (sgbucket.ScanResultIterator, error) {
 	rows, err := c.db().Query(query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("range scan query failed: %w", err)
 	}
 
-	iter := &scanIterator{rows: rows, idsOnly: idsOnly}
+	iter := &scanIterator{rows: rows, idsOnly: opts.IDsOnly}
 	if c.bucket.inMemory {
 		// An in-memory database has only a single connection, so leaving sql.Rows open
 		// can cause deadlock. Read all rows eagerly and close immediately.
-		return preRecordScan(iter), nil
+		return preRecordScan(ctx, iter), nil
 	}
 	return iter, nil
 }
@@ -77,27 +73,34 @@ func (c *Collection) execScan(query string, args []any, idsOnly bool) (sgbucket.
 type scanIterator struct {
 	rows    *sql.Rows
 	idsOnly bool
+	err     error
 }
 
-func (it *scanIterator) Next() *sgbucket.ScanResultItem {
-	if !it.rows.Next() {
+func (it *scanIterator) Next(_ context.Context) *sgbucket.ScanResultItem {
+	if it.err != nil || !it.rows.Next() {
 		return nil
 	}
-	item := &sgbucket.ScanResultItem{IDOnly: it.idsOnly}
-	var err error
+	item := &sgbucket.ScanResultItem{}
 	if it.idsOnly {
-		err = it.rows.Scan(&item.ID, &item.Cas)
+		it.err = it.rows.Scan(&item.ID, &item.Cas)
 	} else {
-		err = it.rows.Scan(&item.ID, &item.Body, &item.Cas)
+		it.err = it.rows.Scan(&item.ID, &item.Body, &item.Cas)
 	}
-	if err != nil {
+	if it.err != nil {
 		return nil
 	}
 	return item
 }
 
-func (it *scanIterator) Close() error {
-	return it.rows.Close()
+func (it *scanIterator) Close(_ context.Context) error {
+	closeErr := it.rows.Close()
+	if it.err == nil {
+		it.err = closeErr
+	}
+	if it.err == nil {
+		it.err = it.rows.Err()
+	}
+	return it.err
 }
 
 // preRecordedScanIterator holds all scan results in memory.
@@ -106,10 +109,10 @@ type preRecordedScanIterator struct {
 	err   error
 }
 
-func preRecordScan(iter *scanIterator) *preRecordedScanIterator {
+func preRecordScan(ctx context.Context, iter *scanIterator) *preRecordedScanIterator {
 	var items []*sgbucket.ScanResultItem
 	for {
-		item := iter.Next()
+		item := iter.Next(ctx)
 		if item == nil {
 			break
 		}
@@ -117,11 +120,11 @@ func preRecordScan(iter *scanIterator) *preRecordedScanIterator {
 	}
 	return &preRecordedScanIterator{
 		items: items,
-		err:   iter.Close(),
+		err:   iter.Close(ctx),
 	}
 }
 
-func (it *preRecordedScanIterator) Next() *sgbucket.ScanResultItem {
+func (it *preRecordedScanIterator) Next(_ context.Context) *sgbucket.ScanResultItem {
 	if len(it.items) == 0 || it.err != nil {
 		return nil
 	}
@@ -130,6 +133,11 @@ func (it *preRecordedScanIterator) Next() *sgbucket.ScanResultItem {
 	return item
 }
 
-func (it *preRecordedScanIterator) Close() error {
+func (it *preRecordedScanIterator) Close(_ context.Context) error {
 	return it.err
 }
+
+var (
+	_ sgbucket.ScanResultIterator = (*scanIterator)(nil)
+	_ sgbucket.ScanResultIterator = (*preRecordedScanIterator)(nil)
+)

--- a/collection+rangescan_test.go
+++ b/collection+rangescan_test.go
@@ -1,0 +1,154 @@
+// Copyright 2025-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rosmar
+
+import (
+	"testing"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRangeScan(t *testing.T) {
+	ensureNoLeaks(t)
+	coll := makeTestBucket(t).DefaultDataStore().(*Collection)
+
+	// Seed test documents
+	docs := map[string]string{
+		"doc_a": `{"name":"alpha"}`,
+		"doc_b": `{"name":"bravo"}`,
+		"doc_c": `{"name":"charlie"}`,
+		"doc_d": `{"name":"delta"}`,
+		"doc_e": `{"name":"echo"}`,
+	}
+	for k, v := range docs {
+		require.NoError(t, coll.SetRaw(k, 0, nil, []byte(v)))
+	}
+
+	t.Run("FullRange", func(t *testing.T) {
+		scan := sgbucket.NewRangeScanForPrefix("doc_")
+		iter, err := coll.Scan(scan, sgbucket.ScanOptions{})
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, iter.Close()) }()
+
+		var ids []string
+		for item := iter.Next(); item != nil; item = iter.Next() {
+			ids = append(ids, item.ID)
+			assert.NotNil(t, item.Body)
+			assert.NotZero(t, item.Cas)
+			assert.False(t, item.IDOnly)
+		}
+		require.Equal(t, []string{"doc_a", "doc_b", "doc_c", "doc_d", "doc_e"}, ids)
+	})
+
+	t.Run("PartialRange", func(t *testing.T) {
+		scan := sgbucket.RangeScan{
+			From: &sgbucket.ScanTerm{Term: "doc_b"},
+			To:   &sgbucket.ScanTerm{Term: "doc_d", Exclusive: true},
+		}
+		iter, err := coll.Scan(scan, sgbucket.ScanOptions{})
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, iter.Close()) }()
+
+		var ids []string
+		for item := iter.Next(); item != nil; item = iter.Next() {
+			ids = append(ids, item.ID)
+		}
+		require.Equal(t, []string{"doc_b", "doc_c"}, ids)
+	})
+
+	t.Run("ExclusiveFrom", func(t *testing.T) {
+		scan := sgbucket.RangeScan{
+			From: &sgbucket.ScanTerm{Term: "doc_a", Exclusive: true},
+			To:   &sgbucket.ScanTerm{Term: "doc_c"},
+		}
+		iter, err := coll.Scan(scan, sgbucket.ScanOptions{})
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, iter.Close()) }()
+
+		var ids []string
+		for item := iter.Next(); item != nil; item = iter.Next() {
+			ids = append(ids, item.ID)
+		}
+		require.Equal(t, []string{"doc_b", "doc_c"}, ids)
+	})
+
+	t.Run("IDsOnly", func(t *testing.T) {
+		scan := sgbucket.NewRangeScanForPrefix("doc_")
+		iter, err := coll.Scan(scan, sgbucket.ScanOptions{IDsOnly: true})
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, iter.Close()) }()
+
+		var ids []string
+		for item := iter.Next(); item != nil; item = iter.Next() {
+			ids = append(ids, item.ID)
+			assert.True(t, item.IDOnly)
+			assert.Nil(t, item.Body)
+		}
+		require.Equal(t, []string{"doc_a", "doc_b", "doc_c", "doc_d", "doc_e"}, ids)
+	})
+
+	t.Run("EmptyRange", func(t *testing.T) {
+		scan := sgbucket.NewRangeScanForPrefix("zzz_nonexistent_")
+		iter, err := coll.Scan(scan, sgbucket.ScanOptions{})
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, iter.Close()) }()
+
+		assert.Nil(t, iter.Next())
+	})
+
+	t.Run("PrefixScan", func(t *testing.T) {
+		scan := sgbucket.NewRangeScanForPrefix("doc_c")
+		iter, err := coll.Scan(scan, sgbucket.ScanOptions{})
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, iter.Close()) }()
+
+		var ids []string
+		for item := iter.Next(); item != nil; item = iter.Next() {
+			ids = append(ids, item.ID)
+		}
+		require.Equal(t, []string{"doc_c"}, ids)
+	})
+
+	t.Run("TombstonesExcluded", func(t *testing.T) {
+		require.NoError(t, coll.Delete("doc_b"))
+
+		scan := sgbucket.NewRangeScanForPrefix("doc_")
+		iter, err := coll.Scan(scan, sgbucket.ScanOptions{})
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, iter.Close()) }()
+
+		var ids []string
+		for item := iter.Next(); item != nil; item = iter.Next() {
+			ids = append(ids, item.ID)
+		}
+		assert.Equal(t, []string{"doc_a", "doc_c", "doc_d", "doc_e"}, ids)
+	})
+
+	t.Run("NoBounds", func(t *testing.T) {
+		scan := sgbucket.RangeScan{}
+		iter, err := coll.Scan(scan, sgbucket.ScanOptions{IDsOnly: true})
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, iter.Close()) }()
+
+		var ids []string
+		for item := iter.Next(); item != nil; item = iter.Next() {
+			ids = append(ids, item.ID)
+		}
+		// doc_b was deleted above, remaining 4 docs should all be returned in order
+		assert.Equal(t, []string{"doc_a", "doc_c", "doc_d", "doc_e"}, ids)
+	})
+
+	t.Run("UnsupportedScanType", func(t *testing.T) {
+		_, err := coll.Scan(nil, sgbucket.ScanOptions{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported scan type")
+	})
+}

--- a/collection+rangescan_test.go
+++ b/collection+rangescan_test.go
@@ -18,9 +18,9 @@ import (
 
 func TestRangeScan(t *testing.T) {
 	ensureNoLeaks(t)
-	coll := makeTestBucket(t).DefaultDataStore().(*Collection)
+	ctx := t.Context()
+	coll := makeTestBucket(t).DefaultDataStore(ctx).(*Collection)
 
-	// Seed test documents
 	docs := map[string]string{
 		"doc_a": `{"name":"alpha"}`,
 		"doc_b": `{"name":"bravo"}`,
@@ -29,23 +29,29 @@ func TestRangeScan(t *testing.T) {
 		"doc_e": `{"name":"echo"}`,
 	}
 	for k, v := range docs {
-		require.NoError(t, coll.SetRaw(k, 0, nil, []byte(v)))
+		require.NoError(t, coll.SetRaw(ctx, k, 0, nil, []byte(v)))
+	}
+
+	collectIDs := func(t *testing.T, iter sgbucket.ScanResultIterator, idsOnly bool) []string {
+		t.Helper()
+		defer func() { assert.NoError(t, iter.Close(ctx)) }()
+		var ids []string
+		for item := iter.Next(ctx); item != nil; item = iter.Next(ctx) {
+			ids = append(ids, item.ID)
+			assert.NotZero(t, item.Cas)
+			if idsOnly {
+				assert.Nil(t, item.Body)
+			} else {
+				assert.NotNil(t, item.Body)
+			}
+		}
+		return ids
 	}
 
 	t.Run("FullRange", func(t *testing.T) {
-		scan := sgbucket.NewRangeScanForPrefix("doc_")
-		iter, err := coll.Scan(scan, sgbucket.ScanOptions{})
+		iter, err := coll.Scan(ctx, sgbucket.NewRangeScanForPrefix("doc_"), sgbucket.ScanOptions{})
 		require.NoError(t, err)
-		defer func() { assert.NoError(t, iter.Close()) }()
-
-		var ids []string
-		for item := iter.Next(); item != nil; item = iter.Next() {
-			ids = append(ids, item.ID)
-			assert.NotNil(t, item.Body)
-			assert.NotZero(t, item.Cas)
-			assert.False(t, item.IDOnly)
-		}
-		require.Equal(t, []string{"doc_a", "doc_b", "doc_c", "doc_d", "doc_e"}, ids)
+		require.Equal(t, []string{"doc_a", "doc_b", "doc_c", "doc_d", "doc_e"}, collectIDs(t, iter, false))
 	})
 
 	t.Run("PartialRange", func(t *testing.T) {
@@ -53,15 +59,9 @@ func TestRangeScan(t *testing.T) {
 			From: &sgbucket.ScanTerm{Term: "doc_b"},
 			To:   &sgbucket.ScanTerm{Term: "doc_d", Exclusive: true},
 		}
-		iter, err := coll.Scan(scan, sgbucket.ScanOptions{})
+		iter, err := coll.Scan(ctx, scan, sgbucket.ScanOptions{})
 		require.NoError(t, err)
-		defer func() { assert.NoError(t, iter.Close()) }()
-
-		var ids []string
-		for item := iter.Next(); item != nil; item = iter.Next() {
-			ids = append(ids, item.ID)
-		}
-		require.Equal(t, []string{"doc_b", "doc_c"}, ids)
+		require.Equal(t, []string{"doc_b", "doc_c"}, collectIDs(t, iter, false))
 	})
 
 	t.Run("ExclusiveFrom", func(t *testing.T) {
@@ -69,85 +69,47 @@ func TestRangeScan(t *testing.T) {
 			From: &sgbucket.ScanTerm{Term: "doc_a", Exclusive: true},
 			To:   &sgbucket.ScanTerm{Term: "doc_c"},
 		}
-		iter, err := coll.Scan(scan, sgbucket.ScanOptions{})
+		iter, err := coll.Scan(ctx, scan, sgbucket.ScanOptions{})
 		require.NoError(t, err)
-		defer func() { assert.NoError(t, iter.Close()) }()
-
-		var ids []string
-		for item := iter.Next(); item != nil; item = iter.Next() {
-			ids = append(ids, item.ID)
-		}
-		require.Equal(t, []string{"doc_b", "doc_c"}, ids)
+		require.Equal(t, []string{"doc_b", "doc_c"}, collectIDs(t, iter, false))
 	})
 
 	t.Run("IDsOnly", func(t *testing.T) {
-		scan := sgbucket.NewRangeScanForPrefix("doc_")
-		iter, err := coll.Scan(scan, sgbucket.ScanOptions{IDsOnly: true})
+		iter, err := coll.Scan(ctx, sgbucket.NewRangeScanForPrefix("doc_"), sgbucket.ScanOptions{IDsOnly: true})
 		require.NoError(t, err)
-		defer func() { assert.NoError(t, iter.Close()) }()
-
-		var ids []string
-		for item := iter.Next(); item != nil; item = iter.Next() {
-			ids = append(ids, item.ID)
-			assert.True(t, item.IDOnly)
-			assert.Nil(t, item.Body)
-		}
-		require.Equal(t, []string{"doc_a", "doc_b", "doc_c", "doc_d", "doc_e"}, ids)
+		require.Equal(t, []string{"doc_a", "doc_b", "doc_c", "doc_d", "doc_e"}, collectIDs(t, iter, true))
 	})
 
 	t.Run("EmptyRange", func(t *testing.T) {
-		scan := sgbucket.NewRangeScanForPrefix("zzz_nonexistent_")
-		iter, err := coll.Scan(scan, sgbucket.ScanOptions{})
+		iter, err := coll.Scan(ctx, sgbucket.NewRangeScanForPrefix("zzz_nonexistent_"), sgbucket.ScanOptions{})
 		require.NoError(t, err)
-		defer func() { assert.NoError(t, iter.Close()) }()
-
-		assert.Nil(t, iter.Next())
+		defer func() { assert.NoError(t, iter.Close(ctx)) }()
+		assert.Nil(t, iter.Next(ctx))
 	})
 
 	t.Run("PrefixScan", func(t *testing.T) {
-		scan := sgbucket.NewRangeScanForPrefix("doc_c")
-		iter, err := coll.Scan(scan, sgbucket.ScanOptions{})
+		iter, err := coll.Scan(ctx, sgbucket.NewRangeScanForPrefix("doc_c"), sgbucket.ScanOptions{})
 		require.NoError(t, err)
-		defer func() { assert.NoError(t, iter.Close()) }()
-
-		var ids []string
-		for item := iter.Next(); item != nil; item = iter.Next() {
-			ids = append(ids, item.ID)
-		}
-		require.Equal(t, []string{"doc_c"}, ids)
+		require.Equal(t, []string{"doc_c"}, collectIDs(t, iter, false))
 	})
 
 	t.Run("TombstonesExcluded", func(t *testing.T) {
-		require.NoError(t, coll.Delete("doc_b"))
+		require.NoError(t, coll.Delete(ctx, "doc_b"))
 
-		scan := sgbucket.NewRangeScanForPrefix("doc_")
-		iter, err := coll.Scan(scan, sgbucket.ScanOptions{})
+		iter, err := coll.Scan(ctx, sgbucket.NewRangeScanForPrefix("doc_"), sgbucket.ScanOptions{})
 		require.NoError(t, err)
-		defer func() { assert.NoError(t, iter.Close()) }()
-
-		var ids []string
-		for item := iter.Next(); item != nil; item = iter.Next() {
-			ids = append(ids, item.ID)
-		}
-		assert.Equal(t, []string{"doc_a", "doc_c", "doc_d", "doc_e"}, ids)
+		assert.Equal(t, []string{"doc_a", "doc_c", "doc_d", "doc_e"}, collectIDs(t, iter, false))
 	})
 
 	t.Run("NoBounds", func(t *testing.T) {
-		scan := sgbucket.RangeScan{}
-		iter, err := coll.Scan(scan, sgbucket.ScanOptions{IDsOnly: true})
+		iter, err := coll.Scan(ctx, sgbucket.RangeScan{}, sgbucket.ScanOptions{IDsOnly: true})
 		require.NoError(t, err)
-		defer func() { assert.NoError(t, iter.Close()) }()
-
-		var ids []string
-		for item := iter.Next(); item != nil; item = iter.Next() {
-			ids = append(ids, item.ID)
-		}
-		// doc_b was deleted above, remaining 4 docs should all be returned in order
-		assert.Equal(t, []string{"doc_a", "doc_c", "doc_d", "doc_e"}, ids)
+		// doc_b was deleted above
+		assert.Equal(t, []string{"doc_a", "doc_c", "doc_d", "doc_e"}, collectIDs(t, iter, true))
 	})
 
 	t.Run("UnsupportedScanType", func(t *testing.T) {
-		_, err := coll.Scan(nil, sgbucket.ScanOptions{})
+		_, err := coll.Scan(ctx, nil, sgbucket.ScanOptions{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported scan type")
 	})

--- a/collection+rangescan_test.go
+++ b/collection+rangescan_test.go
@@ -9,6 +9,7 @@
 package rosmar
 
 import (
+	"sort"
 	"testing"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -32,6 +33,8 @@ func TestRangeScan(t *testing.T) {
 		require.NoError(t, coll.SetRaw(ctx, k, 0, nil, []byte(v)))
 	}
 
+	// Sort returned IDs so tests can use Equal against an ordered expected slice.
+	// Range scan returns no ordering guarantee; consumers must be order-agnostic.
 	collectIDs := func(t *testing.T, iter sgbucket.ScanResultIterator, idsOnly bool) []string {
 		t.Helper()
 		defer func() { assert.NoError(t, iter.Close(ctx)) }()
@@ -45,6 +48,7 @@ func TestRangeScan(t *testing.T) {
 				assert.NotNil(t, item.Body)
 			}
 		}
+		sort.Strings(ids)
 		return ids
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/couchbaselabs/rosmar
 
-go 1.24.0
+go 1.25.0
 
 require (
-	github.com/couchbase/sg-bucket v0.0.0-20260518141224-124a6a2b318e
+	github.com/couchbase/sg-bucket v0.0.0-20260518185934-fd2c2e344237
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-sqlite3 v1.14.42
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/couchbaselabs/rosmar
 go 1.24.0
 
 require (
-	github.com/couchbase/sg-bucket v0.0.0-20260519100927-7e52d6f10caa
+	github.com/couchbase/sg-bucket v0.0.0-20260519125731-9e05bfca7027
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-sqlite3 v1.14.42
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/couchbaselabs/rosmar
 go 1.24.0
 
 require (
-	github.com/couchbase/sg-bucket v0.0.0-20260518185934-fd2c2e344237
+	github.com/couchbase/sg-bucket v0.0.0-20260519100927-7e52d6f10caa
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-sqlite3 v1.14.42
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/couchbaselabs/rosmar
 
-go 1.25.0
+go 1.24.0
 
 require (
 	github.com/couchbase/sg-bucket v0.0.0-20260518185934-fd2c2e344237

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/couchbase/sg-bucket v0.0.0-20260519100927-7e52d6f10caa h1:+PyCQ/N7Dgoc2ldcy1BJTHc9u/TSSjTM2OQaqTAQrRU=
-github.com/couchbase/sg-bucket v0.0.0-20260519100927-7e52d6f10caa/go.mod h1:zZspn0FpL3Q9ol/KN9dpR0u/p5f8cJpETk8GVxcegqA=
+github.com/couchbase/sg-bucket v0.0.0-20260519125731-9e05bfca7027 h1:4Taf1eBfvKZva1e/RrMmiRLBhLfKHd29jtDrSrfJKjc=
+github.com/couchbase/sg-bucket v0.0.0-20260519125731-9e05bfca7027/go.mod h1:zZspn0FpL3Q9ol/KN9dpR0u/p5f8cJpETk8GVxcegqA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/couchbase/sg-bucket v0.0.0-20260518185934-fd2c2e344237 h1:KqPiyDmYV+KzSfMcJl7lBa5UlutkfqE+YG+qRqny1zQ=
-github.com/couchbase/sg-bucket v0.0.0-20260518185934-fd2c2e344237/go.mod h1:zZspn0FpL3Q9ol/KN9dpR0u/p5f8cJpETk8GVxcegqA=
+github.com/couchbase/sg-bucket v0.0.0-20260519100927-7e52d6f10caa h1:+PyCQ/N7Dgoc2ldcy1BJTHc9u/TSSjTM2OQaqTAQrRU=
+github.com/couchbase/sg-bucket v0.0.0-20260519100927-7e52d6f10caa/go.mod h1:zZspn0FpL3Q9ol/KN9dpR0u/p5f8cJpETk8GVxcegqA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/couchbase/sg-bucket v0.0.0-20260518141224-124a6a2b318e h1:tPaPP/sHmz3ACUgEDgRIeM68TLSrEax2zNE17zpe1Mw=
-github.com/couchbase/sg-bucket v0.0.0-20260518141224-124a6a2b318e/go.mod h1:zZspn0FpL3Q9ol/KN9dpR0u/p5f8cJpETk8GVxcegqA=
+github.com/couchbase/sg-bucket v0.0.0-20260518185934-fd2c2e344237 h1:KqPiyDmYV+KzSfMcJl7lBa5UlutkfqE+YG+qRqny1zQ=
+github.com/couchbase/sg-bucket v0.0.0-20260518185934-fd2c2e344237/go.mod h1:zZspn0FpL3Q9ol/KN9dpR0u/p5f8cJpETk8GVxcegqA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
**Note:** This was coded primarily using Opus 4.6 - with manual guidance/verification/review.

Implements `sgbucket.RangeScanStore` on using SQLite queries, enabling range scan-equivalent operations in unit tests without Couchbase Server.

  - Range scans use `WHERE key >= ?` AND `key < ?`, respecting inclusive/exclusive boundaries
  - returns an unordered set of keys (matching gocb's vBucket fan-out->merge result ordering)
  - excludes tombstones (matching CBS behavior)
  - `IDsOnly` mode selects only key and CAS columns
  - Uses preRecordedScanIterator for in-memory databases to avoid single-connection deadlock (same pattern as collection+query.go)
  - Advertises `BucketStoreFeatureRangeScan` as supported

## Dependencies
- [x] https://github.com/couchbase/sg-bucket/pull/139 