### PR TITLE
CBG-5301 make sure to lock before closing bucket

### DIFF
--- a/bucket_api.go
+++ b/bucket_api.go
@@ -88,6 +88,7 @@ func (bucket *Bucket) CloseAndDelete(ctx context.Context) error {
 func (bucket *Bucket) close() error {
 	bucket.mutex.Lock()
 	defer bucket.mutex.Unlock()
+	defer func() { bucket.closed = true }()
 	return bucket._closeSqliteDB()
 }
 

--- a/bucket_api.go
+++ b/bucket_api.go
@@ -77,13 +77,18 @@ func (bucket *Bucket) _closeSqliteDB() error {
 
 // Closes a bucket and deletes its directory and files (unless it's in-memory.)
 func (bucket *Bucket) CloseAndDelete(ctx context.Context) error {
-	bucket.mutex.Lock()
-	defer bucket.mutex.Unlock()
-	err := bucket._closeSqliteDB()
+	err := bucket.close()
 	if err != nil {
 		return err
 	}
 	return deleteBucket(ctx, bucket)
+}
+
+// close a bucket, but doesn't delete its directory or files.
+func (bucket *Bucket) close() error {
+	bucket.mutex.Lock()
+	defer bucket.mutex.Unlock()
+	return bucket._closeSqliteDB()
 }
 
 func (bucket *Bucket) IsSupported(feature sgbucket.BucketStoreFeature) bool {

--- a/bucket_registry.go
+++ b/bucket_registry.go
@@ -87,9 +87,9 @@ func (r *bucketRegistry) unregisterBucket(bucket *Bucket) error {
 		delete(r.bucketCount, name)
 		// if an in memory bucket, don't close the sqlite db since it will vanish
 		if !bucket.inMemory {
-			err := bucket._closeSqliteDB()
-			delete(r.buckets, name)
-			return err
+			// delete from register even if deletion fails
+			defer func() { delete(r.buckets, name) }()
+			return bucket.close()
 		}
 		return nil
 	}


### PR DESCRIPTION
Closing the bucket via `unregisterBucket` would result in calling `_closeSqliteDB` (and subsequent functions) which need to hold bucket.lock

Fixes a data race observation in Sync Gateway, ran the Sync Gateway tests 100 times.