### PR TITLE
Make rosmar DCP checkpoints behave more like CBS

### DIFF
--- a/feeds.go
+++ b/feeds.go
@@ -90,10 +90,11 @@ func (c *Collection) StartDCPFeed(
 ) error {
 	traceEnter("StartDCPFeed", "collection=%s, args=%+v", c, args)
 	feed := &dcpFeed{
-		ctx:        ctx,
-		collection: c,
-		args:       args,
-		callback:   callback,
+		ctx:           ctx,
+		collection:    c,
+		metadataStore: c.bucket.DefaultDataStore().(*Collection),
+		args:          args,
+		callback:      callback,
 	}
 	feed.events.init()
 
@@ -190,12 +191,13 @@ func (c *Collection) _stopFeeds() {
 type eventQueue = queue[*event]
 
 type checkpoint struct {
-	LastSeq uint64 `json:"last_seq"`
+	LastCas map[uint32]uint64 `json:"last_cas"`
 }
 
 type dcpFeed struct {
 	ctx            context.Context // TODO: Use this
 	collection     *Collection
+	metadataStore  *Collection
 	args           sgbucket.FeedArguments
 	callback       sgbucket.FeedEventCallbackFunc
 	events         eventQueue
@@ -208,7 +210,7 @@ func (feed *dcpFeed) String() string {
 }
 
 func (feed *dcpFeed) checkpointKey() string {
-	return feed.args.CheckpointPrefix + ":" + feed.args.ID
+	return feed.args.CheckpointPrefix
 }
 
 // Reads the feed's lastCas from the checkpoint document, if there is one.
@@ -218,7 +220,7 @@ func (feed *dcpFeed) readCheckpoint() (err error) {
 	}
 	key := feed.checkpointKey()
 	var checkpt checkpoint
-	if _, err = feed.collection.Get(key, &checkpt); err != nil {
+	if _, err = feed.metadataStore.Get(key, &checkpt); err != nil {
 		if _, ok := err.(sgbucket.MissingError); ok {
 			err = nil
 			debug("%s checkpoint %q missing", feed, key)
@@ -227,7 +229,10 @@ func (feed *dcpFeed) readCheckpoint() (err error) {
 		}
 		return
 	}
-	feed.lastCas = checkpt.LastSeq
+	if checkpt.LastCas != nil {
+		colID := feed.collection.GetCollectionID()
+		feed.lastCas = checkpt.LastCas[colID]
+	}
 	debug("%s read lastCas 0x%x from %q", feed, feed.lastCas, key)
 	return
 }
@@ -238,11 +243,31 @@ func (feed *dcpFeed) writeCheckpoint() (err error) {
 		return
 	}
 	key := feed.checkpointKey()
-	err = feed.collection.Set(key, 0, nil, checkpoint{LastSeq: feed.lastCas})
+	colID := feed.collection.GetCollectionID()
+
+	_, err = feed.metadataStore.Update(key, 0, func(current []byte) (updated []byte, expiry *uint32, delete bool, err error) {
+		var checkpt checkpoint
+		if current != nil {
+			if err := json.Unmarshal(current, &checkpt); err != nil {
+				return nil, nil, false, fmt.Errorf("failed to unmarshal checkpoint: %w", err)
+			}
+		}
+		if checkpt.LastCas == nil {
+			checkpt.LastCas = make(map[uint32]uint64)
+		}
+		checkpt.LastCas[colID] = feed.lastCas
+
+		updated, err = json.Marshal(checkpt)
+		if err != nil {
+			return nil, nil, false, fmt.Errorf("failed to marshal checkpoint: %w", err)
+		}
+		return updated, nil, false, nil
+	})
+
 	if err == nil {
 		debug("%s wrote lastCas 0x%x to %q", feed, feed.lastCas, key)
 	} else {
-		logError("%s failed to write lastCas to %q: %v", feed, key, err)
+		logError("%s failed to write checkpoint to %q: %v", feed, key, err)
 	}
 	return err
 }

--- a/feeds_test.go
+++ b/feeds_test.go
@@ -128,7 +128,7 @@ func TestCheckpoint(t *testing.T) {
 
 	// The first event will be the writing of the checkpoint itself:
 	e := <-events
-	assert.Equal(t, "Checkpoint:myID", string(e.Key))
+	assert.Equal(t, "Checkpoint", string(e.Key))
 
 	readExpectedEventsDEF(t, events)
 
@@ -137,6 +137,148 @@ func TestCheckpoint(t *testing.T) {
 
 	_, ok = <-doneChan
 	assert.False(t, ok)
+}
+
+func TestResumeFromCheckpoint(t *testing.T) {
+	ensureNoLeakedFeeds(t)
+	bucket := makeTestBucket(t)
+	c := bucket.DefaultDataStore()
+
+	addToCollection(t, c, "doc1", 0, "V1")
+	addToCollection(t, c, "doc2", 0, "V2")
+
+	prefix := "ResumeCheckpoint"
+
+	// Run feed to checkpoint
+	args := sgbucket.FeedArguments{
+		ID:               "myID",
+		Backfill:         sgbucket.FeedResume,
+		Dump:             true,
+		CheckpointPrefix: prefix,
+	}
+	events, doneChan := startFeedWithArgs(t, bucket, args)
+
+	event := <-events
+	assert.Equal(t, sgbucket.FeedOpBeginBackfill, event.Opcode)
+
+	e := <-events
+	assert.Equal(t, "doc1", string(e.Key))
+	e = <-events
+	assert.Equal(t, "doc2", string(e.Key))
+
+	event = <-events
+	assert.Equal(t, sgbucket.FeedOpEndBackfill, event.Opcode)
+
+	<-doneChan
+
+	// Add new docs while feed is off
+	addToCollection(t, c, "doc3", 0, "V3")
+	addToCollection(t, c, "doc4", 0, "V4")
+
+	// Resume feed
+	events, doneChan = startFeedWithArgs(t, bucket, args)
+
+	event = <-events
+	assert.Equal(t, sgbucket.FeedOpBeginBackfill, event.Opcode)
+
+	// First event might be the checkpoint doc itself depending on timing/CAS, but we definitely shouldn't see doc1/doc2 again
+	var seenDocs []string
+	for e := range events {
+		if e.Opcode == sgbucket.FeedOpEndBackfill {
+			break
+		}
+		seenDocs = append(seenDocs, string(e.Key))
+	}
+
+	assert.NotContains(t, seenDocs, "doc1")
+	assert.NotContains(t, seenDocs, "doc2")
+	assert.Contains(t, seenDocs, "doc3")
+	assert.Contains(t, seenDocs, "doc4")
+	assert.Contains(t, seenDocs, prefix) // The checkpoint doc update
+
+	<-doneChan
+}
+
+func TestSharedCheckpoint(t *testing.T) {
+	ensureNoLeakedFeeds(t)
+	bucket := makeTestBucket(t)
+	c1 := bucket.DefaultDataStore().(*Collection)
+	c2, err := bucket.getOrCreateCollection(sgbucket.DataStoreNameImpl{Scope: "S", Collection: "C"}, true)
+	require.NoError(t, err)
+
+	addToCollection(t, c1, "c1-doc", 0, "V1")
+	addToCollection(t, c2, "c2-doc", 0, "V2")
+
+	prefix := "SharedCheckpoint"
+
+	// Run feed for c1
+	args1 := sgbucket.FeedArguments{
+		ID:               "id1",
+		Backfill:         sgbucket.FeedResume,
+		Dump:             true,
+		CheckpointPrefix: prefix,
+	}
+	events1, done1 := startFeedWithArgs(t, bucket, args1)
+	for e := range events1 {
+		if e.Opcode == sgbucket.FeedOpEndBackfill {
+			break
+		}
+	}
+	<-done1
+
+	// Run feed for c2
+	args2 := sgbucket.FeedArguments{
+		ID:               "id2",
+		Backfill:         sgbucket.FeedResume,
+		Dump:             true,
+		CheckpointPrefix: prefix,
+		Scopes:           map[string][]string{"S": {"C"}},
+	}
+	events2, done2 := startFeedWithArgs(t, bucket, args2)
+	for e := range events2 {
+		if e.Opcode == sgbucket.FeedOpEndBackfill {
+			break
+		}
+	}
+	<-done2
+
+	// Verify checkpoint document in DefaultDataStore (c1)
+	var checkpt checkpoint
+	_, err = c1.Get(prefix, &checkpt)
+	require.NoError(t, err)
+	assert.Len(t, checkpt.LastCas, 2)
+	assert.Contains(t, checkpt.LastCas, c1.GetCollectionID())
+	assert.Contains(t, checkpt.LastCas, c2.GetCollectionID())
+
+	// Resume c1 and c2, verify they pick up from where they left off
+	addToCollection(t, c1, "c1-doc2", 0, "V1-2")
+	addToCollection(t, c2, "c2-doc2", 0, "V2-2")
+
+	events1, done1 = startFeedWithArgs(t, bucket, args1)
+	foundC1Doc2 := false
+	for e := range events1 {
+		if string(e.Key) == "c1-doc2" {
+			foundC1Doc2 = true
+		}
+		if e.Opcode == sgbucket.FeedOpEndBackfill {
+			break
+		}
+	}
+	assert.True(t, foundC1Doc2)
+	<-done1
+
+	events2, done2 = startFeedWithArgs(t, bucket, args2)
+	foundC2Doc2 := false
+	for e := range events2 {
+		if string(e.Key) == "c2-doc2" {
+			foundC2Doc2 = true
+		}
+		if e.Opcode == sgbucket.FeedOpEndBackfill {
+			break
+		}
+	}
+	assert.True(t, foundC2Doc2)
+	<-done2
 }
 
 func startFeed(t *testing.T, bucket *Bucket) (events chan sgbucket.FeedEvent, doneChan chan struct{}) {


### PR DESCRIPTION
This closes a few holes that are annoying:

1. Always write checkpoints into the "metadataStore". Probably this metadata store should be passed in should be added to https://github.com/couchbase/sg-bucket/blob/af48ac4b0f246b517dfea26463dc857388b41f42/tap.go#L83. If you are modifying FeedArguments, you might be able to close this gap too https://github.com/couchbase/sync_gateway/blob/98fabec78fab870bc97e38e3ba3502fb9869a44c/base/rosmar_dcp_client.go#L64
2. Write a single checkpoint file rather than multiple checkpoint files, this means I don't have to find all the missing checkpoints. If you ended up using the same checkpoint prefixes but different collections, you could end up finding an old checkpoint. https://github.com/couchbase/sync_gateway/blob/98fabec78fab870bc97e38e3ba3502fb9869a44c/base/rosmar_dcp_client.go#L99 code is currently wrong.
3. Mostly this code will simplify https://github.com/couchbase/sync_gateway/pull/8233 because then I don't have to pass `FeedID` only for rosmar which is the real motivation for doing this PR.

I don't think it's a big deal that we change checkpoint format for rosmar because we don't have a contract to support serialized rosmar buckets.

Ran the Sync Gateway tests.