### PR TITLE
CBG-5411: match Couchbase Server Incr behavior for def > int64 max

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -523,6 +523,12 @@ func (c *Collection) Incr(_ context.Context, key string, amt, deflt uint64, exp 
 		if err == nil {
 			result += amt
 		} else if _, ok := err.(sgbucket.MissingError); ok {
+			// Couchbase Server's gocb adapter casts def to int64; values > math.MaxInt64
+			// become negative, which gocbcore interprets as "do not create if absent"
+			// and the server returns KEY_ENOENT. Match that behavior here.
+			if int64(deflt) < 0 {
+				return nil, sgbucket.MissingError{Key: key}
+			}
 			result = deflt
 		} else {
 			return nil, err

--- a/collection_test.go
+++ b/collection_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -47,25 +48,99 @@ func TestDeleteThenAdd(t *testing.T) {
 	addToCollection(t, coll, "key", 0, "value")
 }
 
+// TestIncr exercises the Incr contract Rosmar shares with Couchbase Server - cross-checked with GoCB/CB Server implementation.
+//
+//   - amt=0 on an existing key still rewrites the doc and bumps CAS (NOT a read-only op).
+//   - Incr uses uint64 addition with wrap on overflow; "negative" amt
+//     (e.g. uint64(-1)) decrements via wrap, with no clamp at 0.
+//   - On a missing key, the delta is not applied — the stored value is def.
+//   - def must fit in int64. CBS's gocb adapter casts def to int64; values
+//     > math.MaxInt64 are interpreted as "do not create if absent" and return
+//     KEY_ENOENT. Rosmar matches this by returning MissingError.
 func TestIncr(t *testing.T) {
 	ctx := t.Context()
 	ensureNoLeaks(t)
 	coll := makeTestBucket(t).DefaultDataStore(ctx)
-	count, err := coll.Incr(ctx, "count1", 1, 100, 0)
-	assert.NoError(t, err, "Incr")
-	assert.Equal(t, uint64(100), count)
 
-	count, err = coll.Incr(ctx, "count1", 0, 0, 0)
-	assert.NoError(t, err, "Incr")
-	assert.Equal(t, uint64(100), count)
+	// intentional underflows (follows GoCB semantics)
+	maxU64 := uint64(math.MaxUint64)
+	negTen := maxU64 - 9 // uint64(-10)
 
-	count, err = coll.Incr(ctx, "count1", 10, 100, 0)
-	assert.NoError(t, err, "Incr")
-	assert.Equal(t, uint64(110), count)
+	cases := []struct {
+		desc             string  // short English description of the scenario
+		existingValue    *uint64 // if non-nil, seed the key via SetRaw before Incr
+		amt              uint64
+		def              uint64
+		expectErr        bool
+		expectValue      uint64
+		expectPostRaw    string
+		expectCASChanged bool // only checked when the doc existed pre-Incr
+	}{
+		{desc: "create zero counter when key missing", amt: 0, def: 0, expectValue: 0, expectPostRaw: "0"},
+		{desc: "create counter at def when key missing", amt: 0, def: 5, expectValue: 5, expectPostRaw: "5"},
+		{desc: "amt=0 on existing key returns current value and ignores def", existingValue: ptr(uint64(42)), amt: 0, def: 100, expectValue: 42, expectPostRaw: "42", expectCASChanged: true},
+		{desc: "missing key returns def, delta is not applied to it", amt: 1, def: 5, expectValue: 5, expectPostRaw: "5"},
+		{desc: "increment existing counter by amt", existingValue: ptr(uint64(42)), amt: 1, def: 5, expectValue: 43, expectPostRaw: "43", expectCASChanged: true},
+		{desc: "amt=0 on existing key still rewrites doc and bumps CAS", existingValue: ptr(uint64(42)), amt: 0, def: 0, expectValue: 42, expectPostRaw: "42", expectCASChanged: true},
+		{desc: "negative amt on missing key stores def (no wrap into def)", amt: maxU64, def: 0, expectValue: 0, expectPostRaw: "0"},
+		{desc: "negative amt on existing key decrements via uint64 wrap", existingValue: ptr(uint64(42)), amt: maxU64, def: 0, expectValue: 41, expectPostRaw: "41", expectCASChanged: true},
+		{desc: "amt=-10 on existing key decrements by 10", existingValue: ptr(uint64(100)), amt: negTen, def: 0, expectValue: 90, expectPostRaw: "90", expectCASChanged: true},
+		{desc: "def > int64 max returns MissingError (matches CBS gocb sentinel)", amt: 1, def: maxU64, expectErr: true},
+		{desc: "def > int64 max is ignored on existing key (delta still applied)", existingValue: ptr(uint64(42)), amt: 1, def: maxU64, expectValue: 43, expectPostRaw: "43", expectCASChanged: true},
+	}
 
-	count, err = coll.Incr(ctx, "count1", 0, 0, 0)
-	assert.NoError(t, err, "Incr")
-	assert.Equal(t, uint64(110), count)
+	// formatU64 renders a uint64 as "negN" when it represents a wrapped-negative int64,
+	// so test names read as the caller-intended value (e.g. uint64(-10) → "neg10").
+	formatU64 := func(v uint64) string {
+		if int64(v) < 0 {
+			return fmt.Sprintf("neg%d", -int64(v))
+		}
+		return strconv.FormatUint(v, 10)
+	}
+
+	for _, tc := range cases {
+		state := "missing"
+		if tc.existingValue != nil {
+			state = fmt.Sprintf("existing%d", *tc.existingValue)
+		}
+		name := fmt.Sprintf("%s/amt=%s_def=%s_%s", tc.desc, formatU64(tc.amt), formatU64(tc.def), state)
+		t.Run(name, func(t *testing.T) {
+			key := name
+
+			if tc.existingValue != nil {
+				raw := []byte(strconv.FormatUint(*tc.existingValue, 10))
+				require.NoError(t, coll.SetRaw(ctx, key, 0, nil, raw), "setup SetRaw")
+			}
+			_, preCAS, preErr := coll.GetRaw(ctx, key)
+
+			value, incrErr := coll.Incr(ctx, key, tc.amt, tc.def, 0)
+
+			if tc.expectErr {
+				require.Error(t, incrErr, "expected Incr to error")
+				require.ErrorAs(t, incrErr, &sgbucket.MissingError{}, "expected MissingError")
+				if tc.existingValue == nil {
+					_, _, postErr := coll.GetRaw(ctx, key)
+					require.Error(t, postErr, "doc should not exist after a failed Incr on missing key")
+				}
+				return
+			}
+
+			require.NoError(t, incrErr)
+			require.Equal(t, tc.expectValue, value, "returned counter value")
+
+			postRaw, postCAS, postErr := coll.GetRaw(ctx, key)
+			require.NoError(t, postErr, "GetRaw after Incr")
+			require.Equal(t, tc.expectPostRaw, string(postRaw), "post-Incr stored value")
+
+			if preErr == nil {
+				if tc.expectCASChanged {
+					require.NotEqual(t, preCAS, postCAS, "CAS should have changed")
+				} else {
+					require.Equal(t, preCAS, postCAS, "CAS should not have changed")
+				}
+			}
+		})
+	}
 }
 
 // Spawns 1000 goroutines that 'simultaneously' use Incr to increment the same counter by 1.

--- a/utils.go
+++ b/utils.go
@@ -182,3 +182,7 @@ var (
 	_ error = &ErrUnimplemented{}
 	_ error = &DatabaseError{}
 )
+
+func ptr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
CBG-5411

When def exceeds `math.MaxInt64`, sync_gateway's gocb-backed `Incr` casts it to int64 (which goes negative), and gocbcore interprets that as the "do not create if absent" sentinel — the server then returns KEY_ENOENT. Rosmar previously created the doc with the wrapped value instead.

Detect the sentinel and return sgbucket.MissingError to match.

TestIncr is now table-driven and covers the matrix verified against both backends: amt=0 (read-but-rewrite + CAS bump), uint64-wrap "negative" amt, missing vs existing key, and the new def-sentinel case in both states. Adds a small ptr[T] helper in utils.go used by the test seed values.